### PR TITLE
test(utils): add phrase_to_seed test suite with BIP39 compliance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,6 +7,7 @@ name = "bip39"
 version = "0.1.0"
 dependencies = [
  "bip39 2.2.0",
+ "hex",
  "rand",
  "thiserror",
 ]
@@ -54,6 +55,12 @@ dependencies = [
  "libc",
  "wasi",
 ]
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hex-conservative"

--- a/crates/bip39/Cargo.toml
+++ b/crates/bip39/Cargo.toml
@@ -7,3 +7,6 @@ edition = "2021"
 bip39-upstream = { package = "bip39", version = "2.0", features = ["all-languages"] }
 thiserror = "1.0"
 rand = "0.8"
+
+[dev-dependencies]
+hex = "0.4"

--- a/crates/bip39/src/lib.rs
+++ b/crates/bip39/src/lib.rs
@@ -8,4 +8,4 @@ mod utils;
 pub use error::{Error, Result};
 pub use language::Language;
 pub use word_count::WordCount;
-pub use utils::{validate_phrase, validate_phrase_in_language};
+pub use utils::{validate_phrase, validate_phrase_in_language, phrase_to_seed};


### PR DESCRIPTION
Implement comprehensive test coverage for phrase_to_seed utility:
- Official BIP39 test vectors for seed derivation validation
- Passphrase security testing (empty, TREZOR, unicode, whitespace)
- Deterministic behavior and case sensitivity verification
- Support for all standard word counts (12/15/18/21/24)
- Proper error handling for invalid inputs