### PR TITLE
feat(bip32): define PrivateKey struct for secp256k1 keys

### DIFF
--- a/crates/bip32/src/lib.rs
+++ b/crates/bip32/src/lib.rs
@@ -42,8 +42,10 @@
 mod chain_code;
 mod error;
 mod network;
+mod private_key;
 
 // Public re-exports
 pub use chain_code::ChainCode;
 pub use error::{Error, Result};
 pub use network::{KeyType, Network};
+pub use private_key::PrivateKey;

--- a/crates/bip32/src/private_key.rs
+++ b/crates/bip32/src/private_key.rs
@@ -1,0 +1,41 @@
+//! Private key implementation for BIP32 hierarchical deterministic wallets.
+//!
+//! This module provides a wrapper around secp256k1 private keys for use in
+//! BIP32 extended key derivation.
+
+use secp256k1::SecretKey;
+
+/// A 32-byte secp256k1 private key used in BIP32 hierarchical deterministic wallets.
+///
+/// Private keys are scalar values on the secp256k1 elliptic curve. They must be
+/// non-zero and less than the curve order to be valid.
+///
+/// # Security
+///
+/// Private keys must be kept secret. Anyone with access to a private key can
+/// spend funds and derive child keys. Always store private keys securely and
+/// never expose them in logs or error messages.
+///
+/// # Examples
+///
+/// ```rust,ignore
+/// use bip32::PrivateKey;
+///
+/// // Create from raw bytes
+/// let bytes = [1u8; 32];
+/// let private_key = PrivateKey::from_bytes(&bytes)?;
+///
+/// // Derive the corresponding public key
+/// let public_key = private_key.public_key();
+/// ```
+#[derive(Clone)]
+pub struct PrivateKey {
+    /// The underlying secp256k1 secret key
+    #[allow(dead_code)]
+    inner: SecretKey,
+}
+
+impl PrivateKey {
+    /// The length of a private key in bytes.
+    pub const LENGTH: usize = 32;
+}

--- a/docs/implementations/bip32_tasks.md
+++ b/docs/implementations/bip32_tasks.md
@@ -14,7 +14,7 @@ Here's your comprehensive task list organized by phases and priority. Each task 
 - ✅ Task 08: Define ChainCode struct (32-byte wrapper)
 - ✅ Task 09: Write tests for ChainCode creation and validation
 - ✅ Task 10: Implement ChainCode methods (TDD)
-- 🔲 Task 11: Define PrivateKey struct (32-byte secp256k1 key)
+- ✅ Task 11: Define PrivateKey struct (32-byte secp256k1 key)
 - 🔲 Task 12: Write tests for PrivateKey creation and validation
 - 🔲 Task 13: Implement PrivateKey methods (TDD)
 - 🔲 Task 14: Define PublicKey struct (33-byte compressed secp256k1 key)


### PR DESCRIPTION
Add PrivateKey struct as a wrapper around secp256k1::SecretKey for BIP-32 hierarchical deterministic key derivation.

Structure:
- Wraps secp256k1::SecretKey for cryptographic operations
- Clone trait for copying private keys
- LENGTH constant = 32 bytes

Documentation:
- Security warnings about keeping private keys secret
- Explanation of secp256k1 curve validation requirements
- Usage examples for future implementation