### PR TITLE
feat(bip32): implement PublicKey with compressed format and ECDSA

### DIFF
--- a/crates/bip32/Cargo.toml
+++ b/crates/bip32/Cargo.toml
@@ -12,6 +12,6 @@ bs58 = { version = "0.5", features = ["check"] }
 secp256k1 = { version = "0.29", features = ["global-context", "rand-std"] }
 thiserror = "1.0"
 zeroize = { version = "1.7", features = ["derive"] }
+hex = "0.4"
 
 [dev-dependencies]
-hex = "0.4"

--- a/crates/bip32/src/lib.rs
+++ b/crates/bip32/src/lib.rs
@@ -43,9 +43,11 @@ mod chain_code;
 mod error;
 mod network;
 mod private_key;
+mod public_key;
 
 // Public re-exports
 pub use chain_code::ChainCode;
 pub use error::{Error, Result};
 pub use network::{KeyType, Network};
 pub use private_key::PrivateKey;
+pub use public_key::PublicKey;

--- a/crates/bip32/src/public_key.rs
+++ b/crates/bip32/src/public_key.rs
@@ -1,0 +1,627 @@
+//! Public key implementation for BIP32 hierarchical deterministic wallets.
+//!
+//! This module provides a wrapper around secp256k1 compressed public keys for use in
+//! BIP32 extended key derivation.
+
+use crate::{Error, PrivateKey, Result};
+use secp256k1::{
+    ecdsa::Signature, scalar::Scalar, Message, PublicKey as Secp256k1PublicKey, SECP256K1,
+};
+
+/// A 33-byte compressed secp256k1 public key used in BIP32 hierarchical deterministic wallets.
+///
+/// Public keys are points on the secp256k1 elliptic curve. BIP32 uses compressed format
+/// (33 bytes: 1-byte prefix + 32-byte x-coordinate) instead of uncompressed format (65 bytes).
+///
+/// # Compressed Format
+///
+/// - **Byte 0**: Prefix (`0x02` for even y, `0x03` for odd y)
+/// - **Bytes 1-32**: x-coordinate of the curve point
+///
+/// # Security
+///
+/// Unlike private keys, public keys are NOT secret and can be safely displayed,
+/// logged, or transmitted.
+///
+/// # Examples
+///
+/// ```rust
+/// use bip32::{PrivateKey, PublicKey};
+///
+/// // Derive from a private key
+/// let private_key = PrivateKey::from_bytes(&[1u8; 32])?;
+/// let public_key = PublicKey::from_private_key(&private_key);
+///
+/// // Get compressed bytes
+/// let bytes = public_key.to_bytes();
+/// assert_eq!(bytes.len(), 33);
+/// # Ok::<(), bip32::Error>(())
+/// ```
+#[derive(Clone, PartialEq, Eq)]
+pub struct PublicKey {
+    /// The underlying secp256k1 public key (always compressed)
+    inner: Secp256k1PublicKey,
+}
+
+impl PublicKey {
+    /// The length of a compressed public key in bytes.
+    pub const COMPRESSED_LENGTH: usize = 33;
+
+    /// The length of an uncompressed public key in bytes.
+    pub const UNCOMPRESSED_LENGTH: usize = 65;
+
+    /// Creates a new `PublicKey` from a secp256k1 `PublicKey`.
+    ///
+    /// # Arguments
+    ///
+    /// * `public_key` - A valid secp256k1 public key
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use bip32::PublicKey;
+    /// use secp256k1::{PublicKey as Secp256k1PublicKey, SecretKey, SECP256K1};
+    ///
+    /// let secret = SecretKey::from_slice(&[1u8; 32]).unwrap();
+    /// let secp_pubkey = Secp256k1PublicKey::from_secret_key(SECP256K1, &secret);
+    /// let public_key = PublicKey::new(secp_pubkey);
+    /// ```
+    pub fn new(public_key: Secp256k1PublicKey) -> Self {
+        PublicKey { inner: public_key }
+    }
+
+    /// Creates a `PublicKey` from a byte slice.
+    ///
+    /// # Arguments
+    ///
+    /// * `bytes` - A byte slice containing either:
+    ///   - 33 bytes for compressed format (recommended)
+    ///   - 65 bytes for uncompressed format (will be converted to compressed)
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::InvalidPublicKey`] if:
+    /// - The slice is not 33 or 65 bytes
+    /// - The bytes represent an invalid secp256k1 public key
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use bip32::{PrivateKey, PublicKey};
+    ///
+    /// let private_key = PrivateKey::from_bytes(&[1u8; 32])?;
+    /// let pubkey_bytes = private_key.public_key().serialize();
+    ///
+    /// let public_key = PublicKey::from_bytes(&pubkey_bytes)?;
+    /// assert_eq!(public_key.to_bytes(), pubkey_bytes);
+    /// # Ok::<(), bip32::Error>(())
+    /// ```
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self> {
+        if bytes.len() != Self::COMPRESSED_LENGTH && bytes.len() != Self::UNCOMPRESSED_LENGTH {
+            return Err(Error::InvalidPublicKey {
+                reason: format!(
+                    "Public key must be {} or {} bytes, got {}",
+                    Self::COMPRESSED_LENGTH,
+                    Self::UNCOMPRESSED_LENGTH,
+                    bytes.len()
+                ),
+            });
+        }
+
+        let public_key =
+            Secp256k1PublicKey::from_slice(bytes).map_err(|e| Error::InvalidPublicKey {
+                reason: format!("Invalid secp256k1 public key: {}", e),
+            })?;
+
+        Ok(PublicKey { inner: public_key })
+    }
+
+    /// Creates a `PublicKey` from a 33-byte compressed array.
+    ///
+    /// # Arguments
+    ///
+    /// * `bytes` - A 33-byte array containing a compressed public key
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::InvalidPublicKey`] if the bytes represent an invalid
+    /// secp256k1 public key.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use bip32::{PrivateKey, PublicKey};
+    ///
+    /// let private_key = PrivateKey::from_bytes(&[1u8; 32])?;
+    /// let bytes = private_key.public_key().serialize();
+    ///
+    /// let public_key = PublicKey::from_array(bytes)?;
+    /// # Ok::<(), bip32::Error>(())
+    /// ```
+    pub fn from_array(bytes: [u8; 33]) -> Result<Self> {
+        Self::from_bytes(&bytes)
+    }
+
+    /// Derives a `PublicKey` from a `PrivateKey`.
+    ///
+    /// # Arguments
+    ///
+    /// * `private_key` - The private key to derive from
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use bip32::{PrivateKey, PublicKey};
+    ///
+    /// let private_key = PrivateKey::from_bytes(&[1u8; 32])?;
+    /// let public_key = PublicKey::from_private_key(&private_key);
+    /// # Ok::<(), bip32::Error>(())
+    /// ```
+    pub fn from_private_key(private_key: &PrivateKey) -> Self {
+        PublicKey {
+            inner: private_key.public_key(),
+        }
+    }
+
+    /// Returns the public key as a 33-byte compressed array.
+    ///
+    /// The format is: `[prefix_byte, x_coordinate[32]]`
+    /// where prefix is `0x02` (even y) or `0x03` (odd y).
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use bip32::{PrivateKey, PublicKey};
+    ///
+    /// let private_key = PrivateKey::from_bytes(&[1u8; 32])?;
+    /// let public_key = PublicKey::from_private_key(&private_key);
+    ///
+    /// let bytes = public_key.to_bytes();
+    /// assert_eq!(bytes.len(), 33);
+    /// assert!(bytes[0] == 0x02 || bytes[0] == 0x03);
+    /// # Ok::<(), bip32::Error>(())
+    /// ```
+    pub fn to_bytes(&self) -> [u8; 33] {
+        self.inner.serialize()
+    }
+
+    /// Returns the public key as a 65-byte uncompressed array.
+    ///
+    /// The format is: `[0x04, x_coordinate[32], y_coordinate[32]]`
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use bip32::{PrivateKey, PublicKey};
+    ///
+    /// let private_key = PrivateKey::from_bytes(&[1u8; 32])?;
+    /// let public_key = PublicKey::from_private_key(&private_key);
+    ///
+    /// let bytes = public_key.to_uncompressed();
+    /// assert_eq!(bytes.len(), 65);
+    /// assert_eq!(bytes[0], 0x04);
+    /// # Ok::<(), bip32::Error>(())
+    /// ```
+    pub fn to_uncompressed(&self) -> [u8; 65] {
+        self.inner.serialize_uncompressed()
+    }
+
+    /// Returns a reference to the underlying secp256k1 `PublicKey`.
+    ///
+    /// This is useful for performing secp256k1 operations directly.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use bip32::{PrivateKey, PublicKey};
+    ///
+    /// let private_key = PrivateKey::from_bytes(&[1u8; 32])?;
+    /// let public_key = PublicKey::from_private_key(&private_key);
+    ///
+    /// let secp_pubkey = public_key.public_key();
+    /// # Ok::<(), bip32::Error>(())
+    /// ```
+    pub fn public_key(&self) -> &Secp256k1PublicKey {
+        &self.inner
+    }
+
+    /// Returns `true` if the public key is in compressed format.
+    ///
+    /// Since BIP32 always uses compressed keys, this always returns `true`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use bip32::{PrivateKey, PublicKey};
+    ///
+    /// let private_key = PrivateKey::from_bytes(&[1u8; 32])?;
+    /// let public_key = PublicKey::from_private_key(&private_key);
+    ///
+    /// assert!(public_key.is_compressed());
+    /// # Ok::<(), bip32::Error>(())
+    /// ```
+    pub fn is_compressed(&self) -> bool {
+        true // BIP32 always uses compressed keys
+    }
+
+    /// Adds a scalar value to this public key (for BIP32 child key derivation).
+    ///
+    /// This performs elliptic curve point addition: `new_key = self + tweak * G`
+    /// where `G` is the generator point. This is used in BIP32 for deriving
+    /// public child keys from a parent public key (normal derivation only).
+    ///
+    /// # Arguments
+    ///
+    /// * `tweak` - A 32-byte scalar value to add to this key
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::InvalidPublicKey`] if:
+    /// - The tweak is not exactly 32 bytes
+    /// - The resulting point would be invalid (e.g., point at infinity)
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use bip32::{PrivateKey, PublicKey};
+    ///
+    /// let private_key = PrivateKey::from_bytes(&[1u8; 32])?;
+    /// let public_key = PublicKey::from_private_key(&private_key);
+    ///
+    /// let tweak = [2u8; 32];
+    /// let derived_key = public_key.tweak_add(&tweak)?;
+    /// # Ok::<(), bip32::Error>(())
+    /// ```
+    pub fn tweak_add(&self, tweak: &[u8]) -> Result<Self> {
+        if tweak.len() != 32 {
+            return Err(Error::InvalidPublicKey {
+                reason: format!("Tweak must be 32 bytes, got {}", tweak.len()),
+            });
+        }
+
+        // Convert tweak bytes to Scalar
+        let mut tweak_array = [0u8; 32];
+        tweak_array.copy_from_slice(tweak);
+        let scalar = Scalar::from_be_bytes(tweak_array).map_err(|_| Error::InvalidPublicKey {
+            reason: "Invalid tweak scalar".to_string(),
+        })?;
+
+        let tweaked = self.inner.add_exp_tweak(SECP256K1, &scalar).map_err(|e| {
+            Error::InvalidPublicKey {
+                reason: format!("Failed to add tweak: {}", e),
+            }
+        })?;
+
+        Ok(PublicKey { inner: tweaked })
+    }
+
+    /// Verifies an ECDSA signature against a message hash.
+    ///
+    /// # Arguments
+    ///
+    /// * `message` - The 32-byte message hash that was signed
+    /// * `signature` - The ECDSA signature to verify
+    ///
+    /// # Returns
+    ///
+    /// Returns `true` if the signature is valid, `false` otherwise.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use bip32::{PrivateKey, PublicKey};
+    /// use secp256k1::{Message, Secp256k1};
+    ///
+    /// let secp = Secp256k1::new();
+    /// let private_key = PrivateKey::from_bytes(&[1u8; 32])?;
+    /// let public_key = PublicKey::from_private_key(&private_key);
+    ///
+    /// // Sign a message
+    /// let message = Message::from_digest_slice(&[0xAB; 32]).unwrap();
+    /// let signature = secp.sign_ecdsa(&message, private_key.secret_key());
+    ///
+    /// // Verify the signature
+    /// assert!(public_key.verify_signature(&message, &signature));
+    /// # Ok::<(), bip32::Error>(())
+    /// ```
+    pub fn verify_signature(&self, message: &Message, signature: &Signature) -> bool {
+        SECP256K1
+            .verify_ecdsa(message, signature, &self.inner)
+            .is_ok()
+    }
+}
+
+impl std::fmt::Debug for PublicKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "PublicKey({})", hex::encode(self.to_bytes()))
+    }
+}
+
+impl std::fmt::Display for PublicKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", hex::encode(self.to_bytes()))
+    }
+}
+
+impl From<Secp256k1PublicKey> for PublicKey {
+    fn from(public_key: Secp256k1PublicKey) -> Self {
+        PublicKey::new(public_key)
+    }
+}
+
+impl TryFrom<&[u8]> for PublicKey {
+    type Error = Error;
+
+    fn try_from(bytes: &[u8]) -> Result<Self> {
+        PublicKey::from_bytes(bytes)
+    }
+}
+
+impl TryFrom<[u8; 33]> for PublicKey {
+    type Error = Error;
+
+    fn try_from(bytes: [u8; 33]) -> Result<Self> {
+        PublicKey::from_array(bytes)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use secp256k1::{Secp256k1, SecretKey};
+
+    fn create_test_private_key() -> PrivateKey {
+        PrivateKey::from_bytes(&[1u8; 32]).unwrap()
+    }
+
+    #[test]
+    fn test_public_key_new() {
+        let secret = SecretKey::from_slice(&[1u8; 32]).unwrap();
+        let secp_pubkey = Secp256k1PublicKey::from_secret_key(SECP256K1, &secret);
+        let public_key = PublicKey::new(secp_pubkey);
+        assert_eq!(public_key.to_bytes().len(), 33);
+    }
+
+    #[test]
+    fn test_public_key_from_private_key() {
+        let private_key = create_test_private_key();
+        let public_key = PublicKey::from_private_key(&private_key);
+        assert_eq!(public_key.to_bytes().len(), 33);
+    }
+
+    #[test]
+    fn test_public_key_from_bytes_compressed() {
+        let private_key = create_test_private_key();
+        let bytes = private_key.public_key().serialize();
+        let public_key = PublicKey::from_bytes(&bytes).unwrap();
+        assert_eq!(public_key.to_bytes(), bytes);
+    }
+
+    #[test]
+    fn test_public_key_from_bytes_uncompressed() {
+        let private_key = create_test_private_key();
+        let secp_pubkey = private_key.public_key();
+        let uncompressed = secp_pubkey.serialize_uncompressed();
+
+        let public_key = PublicKey::from_bytes(&uncompressed).unwrap();
+        assert_eq!(public_key.to_bytes(), secp_pubkey.serialize());
+    }
+
+    #[test]
+    fn test_public_key_from_bytes_invalid_length() {
+        let bytes = [0u8; 32]; // Wrong length
+        let result = PublicKey::from_bytes(&bytes);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("must be 33 or 65 bytes"));
+    }
+
+    #[test]
+    fn test_public_key_from_bytes_invalid_data() {
+        let bytes = [0xFFu8; 33]; // Invalid public key
+        let result = PublicKey::from_bytes(&bytes);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_public_key_from_array() {
+        let private_key = create_test_private_key();
+        let bytes = private_key.public_key().serialize();
+        let public_key = PublicKey::from_array(bytes).unwrap();
+        assert_eq!(public_key.to_bytes(), bytes);
+    }
+
+    #[test]
+    fn test_public_key_to_bytes() {
+        let private_key = create_test_private_key();
+        let public_key = PublicKey::from_private_key(&private_key);
+        let bytes = public_key.to_bytes();
+
+        assert_eq!(bytes.len(), 33);
+        assert!(bytes[0] == 0x02 || bytes[0] == 0x03);
+    }
+
+    #[test]
+    fn test_public_key_to_uncompressed() {
+        let private_key = create_test_private_key();
+        let public_key = PublicKey::from_private_key(&private_key);
+        let bytes = public_key.to_uncompressed();
+
+        assert_eq!(bytes.len(), 65);
+        assert_eq!(bytes[0], 0x04);
+    }
+
+    #[test]
+    fn test_public_key_compression() {
+        let private_key = create_test_private_key();
+        let public_key = PublicKey::from_private_key(&private_key);
+
+        let compressed = public_key.to_bytes();
+        let uncompressed = public_key.to_uncompressed();
+
+        // Both formats should represent the same key
+        let pub1 = PublicKey::from_bytes(&compressed).unwrap();
+        let pub2 = PublicKey::from_bytes(&uncompressed).unwrap();
+        assert_eq!(pub1, pub2);
+    }
+
+    #[test]
+    fn test_public_key_public_key() {
+        let private_key = create_test_private_key();
+        let public_key = PublicKey::from_private_key(&private_key);
+        let secp_pubkey = public_key.public_key();
+        assert_eq!(secp_pubkey.serialize(), public_key.to_bytes());
+    }
+
+    #[test]
+    fn test_public_key_is_compressed() {
+        let private_key = create_test_private_key();
+        let public_key = PublicKey::from_private_key(&private_key);
+        assert!(public_key.is_compressed());
+    }
+
+    #[test]
+    fn test_public_key_clone() {
+        let private_key = create_test_private_key();
+        let public_key1 = PublicKey::from_private_key(&private_key);
+        let public_key2 = public_key1.clone();
+        assert_eq!(public_key1, public_key2);
+    }
+
+    #[test]
+    fn test_public_key_equality() {
+        let private_key1 = PrivateKey::from_bytes(&[1u8; 32]).unwrap();
+        let private_key2 = PrivateKey::from_bytes(&[1u8; 32]).unwrap();
+        let private_key3 = PrivateKey::from_bytes(&[2u8; 32]).unwrap();
+
+        let pub1 = PublicKey::from_private_key(&private_key1);
+        let pub2 = PublicKey::from_private_key(&private_key2);
+        let pub3 = PublicKey::from_private_key(&private_key3);
+
+        assert_eq!(pub1, pub2);
+        assert_ne!(pub1, pub3);
+    }
+
+    #[test]
+    fn test_public_key_debug() {
+        let private_key = create_test_private_key();
+        let public_key = PublicKey::from_private_key(&private_key);
+        let debug_str = format!("{:?}", public_key);
+
+        assert!(debug_str.contains("PublicKey"));
+        assert!(debug_str.len() > 20); // Should show hex
+    }
+
+    #[test]
+    fn test_public_key_display() {
+        let private_key = create_test_private_key();
+        let public_key = PublicKey::from_private_key(&private_key);
+        let display_str = format!("{}", public_key);
+
+        assert_eq!(display_str.len(), 66); // 33 bytes * 2 hex chars
+    }
+
+    #[test]
+    fn test_public_key_from_secp256k1() {
+        let secret = SecretKey::from_slice(&[1u8; 32]).unwrap();
+        let secp_pubkey = Secp256k1PublicKey::from_secret_key(SECP256K1, &secret);
+        let public_key: PublicKey = secp_pubkey.into();
+        assert_eq!(public_key.to_bytes(), secp_pubkey.serialize());
+    }
+
+    #[test]
+    fn test_public_key_try_from_slice() {
+        let private_key = create_test_private_key();
+        let bytes = private_key.public_key().serialize();
+        let slice: &[u8] = &bytes;
+        let public_key = PublicKey::try_from(slice).unwrap();
+        assert_eq!(public_key.to_bytes(), bytes);
+    }
+
+    #[test]
+    fn test_public_key_try_from_array() {
+        let private_key = create_test_private_key();
+        let bytes = private_key.public_key().serialize();
+        let public_key = PublicKey::try_from(bytes).unwrap();
+        assert_eq!(public_key.to_bytes(), bytes);
+    }
+
+    #[test]
+    fn test_public_key_tweak_add_valid() {
+        let private_key = create_test_private_key();
+        let public_key = PublicKey::from_private_key(&private_key);
+
+        let tweak = [2u8; 32];
+        let derived = public_key.tweak_add(&tweak).unwrap();
+
+        assert_ne!(derived, public_key);
+    }
+
+    #[test]
+    fn test_public_key_tweak_add_invalid_length() {
+        let private_key = create_test_private_key();
+        let public_key = PublicKey::from_private_key(&private_key);
+
+        let tweak = [1u8; 16];
+        let result = public_key.tweak_add(&tweak);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_public_key_tweak_add_matches_private() {
+        // Verify that pub_parent + tweak == (priv_parent + tweak).public_key()
+        let priv_parent = PrivateKey::from_bytes(&[10u8; 32]).unwrap();
+        let pub_parent = PublicKey::from_private_key(&priv_parent);
+
+        let tweak = [5u8; 32];
+
+        let priv_derived = priv_parent.tweak_add(&tweak).unwrap();
+        let pub_from_priv = PublicKey::from_private_key(&priv_derived);
+
+        let pub_derived = pub_parent.tweak_add(&tweak).unwrap();
+
+        assert_eq!(pub_from_priv, pub_derived);
+    }
+
+    #[test]
+    fn test_public_key_verify_signature_valid() {
+        let secp = Secp256k1::new();
+        let private_key = create_test_private_key();
+        let public_key = PublicKey::from_private_key(&private_key);
+
+        let message = Message::from_digest_slice(&[0xAB; 32]).unwrap();
+        let signature = secp.sign_ecdsa(&message, private_key.secret_key());
+
+        assert!(public_key.verify_signature(&message, &signature));
+    }
+
+    #[test]
+    fn test_public_key_verify_signature_invalid() {
+        let secp = Secp256k1::new();
+        let private_key1 = PrivateKey::from_bytes(&[1u8; 32]).unwrap();
+        let private_key2 = PrivateKey::from_bytes(&[2u8; 32]).unwrap();
+        let public_key1 = PublicKey::from_private_key(&private_key1);
+
+        let message = Message::from_digest_slice(&[0xAB; 32]).unwrap();
+        let signature = secp.sign_ecdsa(&message, private_key2.secret_key());
+
+        // Wrong public key, should fail
+        assert!(!public_key1.verify_signature(&message, &signature));
+    }
+
+    #[test]
+    fn test_public_key_length_constants() {
+        assert_eq!(PublicKey::COMPRESSED_LENGTH, 33);
+        assert_eq!(PublicKey::UNCOMPRESSED_LENGTH, 65);
+    }
+
+    #[test]
+    fn test_public_key_deterministic() {
+        let private_key = create_test_private_key();
+        let pub1 = PublicKey::from_private_key(&private_key);
+        let pub2 = PublicKey::from_private_key(&private_key);
+        assert_eq!(pub1, pub2);
+    }
+}

--- a/docs/implementations/bip32_tasks.md
+++ b/docs/implementations/bip32_tasks.md
@@ -17,9 +17,9 @@ Here's your comprehensive task list organized by phases and priority. Each task 
 - ✅ Task 11: Define PrivateKey struct (32-byte secp256k1 key)
 - ✅ Task 12: Write tests for PrivateKey creation and validation
 - ✅ Task 13: Implement PrivateKey methods (TDD)
-- 🔲 Task 14: Define PublicKey struct (33-byte compressed secp256k1 key)
-- 🔲 Task 15: Write tests for PublicKey creation and derivation from PrivateKey
-- 🔲 Task 16: Implement PublicKey methods (TDD)
+- ✅ Task 14: Define PublicKey struct (33-byte compressed secp256k1 key)
+- ✅ Task 15: Write tests for PublicKey creation and derivation from PrivateKey
+- ✅ Task 16: Implement PublicKey methods (TDD)
 
 ## 🏗️ PHASE 3: Extended Key Structure (HIGH → MEDIUM Priority)
 - 🔲 Task 17: Define ExtendedPrivateKey struct (key + chain_code + depth + fingerprint + child_number)


### PR DESCRIPTION
Add complete PublicKey implementation wrapping secp256k1::PublicKey with BIP-32 compressed format (33 bytes) and cryptographic operations.

Features:
- Constructors: new(), from_bytes(), from_array(), from_private_key()
- Format support: compressed (33 bytes) and uncompressed (65 bytes)
- Getters: to_bytes(), to_uncompressed(), public_key(), is_compressed()
- Cryptographic ops: tweak_add() for public derivation, verify_signature()
- Traits: Clone, PartialEq, Eq, Debug (shows hex), Display

Key Implementation Details:
- BIP-32 standard: always stores as compressed (33 bytes)
- Auto-converts uncompressed input (65 bytes) to compressed
- tweak_add() verified to match (priv + tweak).public_key()
- ECDSA signature verification with secp256k1
- Public keys are NOT secret: Debug/Display show full hex
- No zeroization needed (unlike PrivateKey)

Constants:
- COMPRESSED_LENGTH = 33 bytes
- UNCOMPRESSED_LENGTH = 65 bytes

Why 33 bytes compressed?
- Elliptic curve point: (x, y) where y² = x³ + 7
- Only 2 possible y values for any x (even/odd)
- Format: [prefix_byte (0x02/0x03), x_coordinate (32 bytes)]

Dependencies added:
- hex 0.4 moved to main dependencies for Debug/Display formatting

Tests: 26 comprehensive unit tests + 11 doc tests - all passing