### PR TITLE
feat(bip32): define ExtendedPublicKey struct for watch-only wallets

### DIFF
--- a/crates/bip32/src/extended_public_key.rs
+++ b/crates/bip32/src/extended_public_key.rs
@@ -1,0 +1,120 @@
+//! Extended public key implementation for BIP32 hierarchical deterministic wallets.
+//!
+//! This module provides the ExtendedPublicKey type which combines a public key
+//! with metadata necessary for hierarchical key derivation according to BIP-32.
+
+use crate::{ChainCode, Network, PublicKey};
+
+/// An extended public key for BIP32 hierarchical deterministic wallets.
+///
+/// Extended public keys combine a public key with additional metadata required for
+/// hierarchical key derivation. Unlike extended private keys, extended public keys
+/// can only derive non-hardened (normal) child keys.
+///
+/// # Structure
+///
+/// An extended public key contains:
+/// - **Public Key**: The 33-byte compressed secp256k1 public key
+/// - **Chain Code**: 32 bytes of entropy used in child key derivation
+/// - **Depth**: The depth in the derivation tree (0 for master, 1 for level-1, etc.)
+/// - **Parent Fingerprint**: First 4 bytes of parent public key hash (for identification)
+/// - **Child Number**: The index of this key in its parent's children
+/// - **Network**: The network this key is for (mainnet, testnet, etc.)
+///
+/// # Serialization Format
+///
+/// Extended public keys serialize to 78 bytes before Base58Check encoding:
+/// ```text
+/// [4 bytes]  version        (network-dependent, e.g., 0x0488B21E for mainnet)
+/// [1 byte]   depth          (0x00 for master)
+/// [4 bytes]  fingerprint    (0x00000000 for master)
+/// [4 bytes]  child_number   (0x00000000 for master)
+/// [32 bytes] chain_code     (entropy for derivation)
+/// [33 bytes] key_data       (33-byte compressed public key)
+/// ```
+///
+/// After Base58Check encoding, this becomes the familiar `xpub...` or `tpub...` string.
+///
+/// # Limitations
+///
+/// Extended public keys can only derive **normal (non-hardened)** child keys.
+/// Hardened derivation requires the private key and cannot be performed with
+/// only the public key. This is a security feature of BIP-32.
+///
+/// # Use Cases
+///
+/// Extended public keys are useful for:
+/// - **Watch-only wallets**: Monitor balances without signing capability
+/// - **Receiving addresses**: Generate new addresses without exposing private keys
+/// - **Audit purposes**: Allow third parties to view transaction history
+/// - **Point-of-sale systems**: Generate payment addresses without security risk
+///
+/// # Examples
+///
+/// ```rust,ignore
+/// use bip32::{ExtendedPrivateKey, ExtendedPublicKey, Network};
+///
+/// // Generate master private key from seed
+/// let seed = [0u8; 64];
+/// let master_priv = ExtendedPrivateKey::from_seed(&seed, Network::BitcoinMainnet)?;
+///
+/// // Derive extended public key
+/// let master_pub = master_priv.to_extended_public_key();
+///
+/// // Extended public key can derive normal children
+/// let child_pub = master_pub.derive_child(0)?;  // OK - normal derivation
+/// let hardened = master_pub.derive_child(0x80000000)?;  // ERROR - hardened not allowed
+/// ```
+#[derive(Clone, PartialEq, Eq)]
+pub struct ExtendedPublicKey {
+    /// The network this key belongs to (Bitcoin mainnet, testnet, etc.)
+    network: Network,
+
+    /// Depth in the derivation tree.
+    /// - 0 = master key
+    /// - 1 = first-level child
+    /// - 2 = second-level child
+    /// - etc.
+    ///
+    /// Maximum depth is 255 according to BIP-32.
+    depth: u8,
+
+    /// The first 4 bytes of the parent key's public key hash (HASH160).
+    /// Used to quickly identify the parent key.
+    /// Set to [0, 0, 0, 0] for the master key.
+    parent_fingerprint: [u8; 4],
+
+    /// The child index used to derive this key from its parent.
+    /// - Values 0 to 2^31-1 (0x7FFFFFFF): normal derivation (allowed)
+    /// - Values 2^31 to 2^32-1 (0x80000000+): hardened derivation (NOT allowed)
+    ///
+    /// Set to 0 for the master key.
+    ///
+    /// **Important**: Extended public keys cannot derive hardened children.
+    /// Attempting to derive a hardened child will result in an error.
+    child_number: u32,
+
+    /// The chain code used for deriving child keys.
+    /// This provides additional entropy beyond the public key itself,
+    /// enabling secure hierarchical key derivation.
+    ///
+    /// The chain code is the same for corresponding extended private and
+    /// public key pairs.
+    chain_code: ChainCode,
+
+    /// The compressed secp256k1 public key (33 bytes).
+    /// This is used for verification and deriving child public keys.
+    public_key: PublicKey,
+}
+
+impl ExtendedPublicKey {
+    /// The maximum allowed depth in the derivation tree.
+    /// This is a BIP-32 specification limit.
+    pub const MAX_DEPTH: u8 = 255;
+
+    /// The threshold for hardened derivation.
+    /// Child numbers >= this value are considered hardened.
+    ///
+    /// **Note**: Extended public keys cannot derive hardened children.
+    pub const HARDENED_BIT: u32 = 0x80000000; // 2^31
+}

--- a/crates/bip32/src/lib.rs
+++ b/crates/bip32/src/lib.rs
@@ -42,6 +42,7 @@
 mod chain_code;
 mod error;
 mod extended_private_key;
+mod extended_public_key;
 mod network;
 mod private_key;
 mod public_key;
@@ -50,6 +51,7 @@ mod public_key;
 pub use chain_code::ChainCode;
 pub use error::{Error, Result};
 pub use extended_private_key::ExtendedPrivateKey;
+pub use extended_public_key::ExtendedPublicKey;
 pub use network::{KeyType, Network};
 pub use private_key::PrivateKey;
 pub use public_key::PublicKey;

--- a/docs/implementations/bip32_tasks.md
+++ b/docs/implementations/bip32_tasks.md
@@ -23,7 +23,7 @@ Here's your comprehensive task list organized by phases and priority. Each task 
 
 ## 🏗️ PHASE 3: Extended Key Structure (HIGH → MEDIUM Priority)
 - ✅ Task 17: Define ExtendedPrivateKey struct (key + chain_code + depth + fingerprint + child_number)
-- 🔲 Task 18: Define ExtendedPublicKey struct (key + chain_code + depth + fingerprint + child_number)
+- ✅ Task 18: Define ExtendedPublicKey struct (key + chain_code + depth + fingerprint + child_number)
 - 🔲 Task 19: Write tests for ExtendedPrivateKey::from_seed() (master key generation)
 - 🔲 Task 20: Implement ExtendedPrivateKey::from_seed() with HMAC-SHA512 (TDD)
 - 🔲 Task 21: Write tests for ExtendedPrivateKey::to_extended_public_key()


### PR DESCRIPTION
Add ExtendedPublicKey struct definition with all BIP-32 hierarchical metadata required for public key derivation (normal derivation only).

Structure (78 bytes when serialized):
- network: Network (mainnet/testnet)
- depth: u8 (tree level, 0 = master, max 255)
- parent_fingerprint: [u8; 4] (parent key identifier)
- child_number: u32 (child index, hardened NOT allowed)
- chain_code: ChainCode (32-byte derivation entropy, same as private)
- public_key: PublicKey (33-byte compressed secp256k1 key)

Key differences from ExtendedPrivateKey:
- Stores PublicKey (33 bytes) instead of PrivateKey (32 bytes)
- Cannot derive hardened children (security feature)
- Can only perform normal (non-hardened) derivation
- Serializes to xpub/tpub instead of xprv/tprv

Shared metadata with ExtendedPrivateKey:
- Same network, depth, parent_fingerprint, child_number
- SAME chain_code (critical for derivation consistency)
- Ensures private-derived and public-derived children match

Constants:
- MAX_DEPTH = 255 (BIP-32 specification limit)
- HARDENED_BIT = 0x80000000 (threshold for hardened derivation)

Use cases:
- Watch-only wallets (monitor without signing)
- Generating receiving addresses
- Audit purposes
- Point-of-sale systems