### PR TITLE
feat(bip32): implement fingerprint calculation and add ExtendedPublic…

### DIFF
--- a/docs/implementations/bip32_tasks.md
+++ b/docs/implementations/bip32_tasks.md
@@ -28,8 +28,8 @@ Here's your comprehensive task list organized by phases and priority. Each task 
 - ✅ Task 20: Implement ExtendedPrivateKey::from_seed() with HMAC-SHA512 (TDD)
 - ✅ Task 21: Write tests for ExtendedPrivateKey::to_extended_public_key()
 - ✅ Task 22: Implement ExtendedPrivateKey::to_extended_public_key() (TDD)
-- 🔲 Task 23: Write tests for fingerprint calculation
-- 🔲 Task 24: Implement fingerprint calculation methods (TDD)
+- ✅ Task 23: Write tests for fingerprint calculation
+- ✅ Task 24: Implement fingerprint calculation methods (TDD)
 
 ## 🛤️ PHASE 4: Derivation Path Parsing (MEDIUM Priority)
 - 🔲 Task 25: Define DerivationPath struct to hold path components


### PR DESCRIPTION
…Key tests

1. Fingerprint Calculation (HASH160)
   - fingerprint = RIPEMD160(SHA256(public_key))[0..4]
   - Implemented for both ExtendedPrivateKey and ExtendedPublicKey
   - Used for parent identification in BIP-32 derivation
   - Tests: 7 new tests including BIP-32 test vector ✓

2. ExtendedPublicKey Unit Tests
   - Added 14 comprehensive unit tests previously missing
   - Tests constructor, getters, traits, fingerprint, boundaries
   - Verifies Debug shows actual data (not redacted like private key)
   - Validates chain code independence

Total: 145 tests passing (+21 new tests)

BIP-32 fingerprint test vector validated: 3442193e ✓