### PR TITLE
feat(bip32): add DerivationPath struct (Task 25)

### DIFF
--- a/crates/bip32/src/child_number.rs
+++ b/crates/bip32/src/child_number.rs
@@ -1,0 +1,55 @@
+//! Child number types for BIP-32 key derivation.
+//!
+//! This module provides the `ChildNumber` enum which represents an index used
+//! in BIP-32 hierarchical key derivation. Child numbers can be either "normal"
+//! (non-hardened) or "hardened".
+//!
+//! NOTE: This is a minimal definition to support DerivationPath (Task 25).
+//! Full implementation will be added in Task 26-28.
+
+/// A child number for BIP-32 key derivation.
+///
+/// Child numbers can be either:
+/// - **Normal (Non-hardened)**: Allows deriving public child keys from public parent keys
+/// - **Hardened**: Requires the private parent key; more secure but less flexible
+///
+/// The hardened bit (2^31) determines the type:
+/// - `0` to `2^31-1` (0 to 2,147,483,647): Normal child numbers
+/// - `2^31` to `2^32-1` (2,147,483,648 to 4,294,967,295): Hardened child numbers
+///
+/// # Notation
+///
+/// In BIP-32 path notation:
+/// - `0` represents Normal(0)
+/// - `0'` or `0h` represents Hardened(0)
+/// - `44'` represents Hardened(44)
+///
+/// # Examples
+///
+/// ```rust,ignore
+/// use bip32::ChildNumber;
+///
+/// // Normal child number
+/// let normal = ChildNumber::Normal(0);
+///
+/// // Hardened child number (often written as 44')
+/// let hardened = ChildNumber::Hardened(44);
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ChildNumber {
+    /// Normal (non-hardened) derivation.
+    ///
+    /// Index range: 0 to 2^31-1 (0x00000000 to 0x7FFFFFFF)
+    ///
+    /// Normal derivation allows deriving child public keys from the parent
+    /// public key without needing the private key.
+    Normal(u32),
+
+    /// Hardened derivation.
+    ///
+    /// Index range: 0 to 2^31-1 (stored value, actual index is value + 2^31)
+    ///
+    /// Hardened derivation requires the parent private key and provides
+    /// better security by preventing public key derivation.
+    Hardened(u32),
+}

--- a/crates/bip32/src/derivation_path.rs
+++ b/crates/bip32/src/derivation_path.rs
@@ -1,0 +1,229 @@
+//! BIP-32 derivation path implementation.
+//!
+//! This module provides the `DerivationPath` struct which represents a path in the
+//! BIP-32 hierarchical deterministic key tree. Derivation paths specify how to derive
+//! child keys from a master key by following a sequence of child indices.
+//!
+//! # Path Format
+//!
+//! Derivation paths follow the BIP-32 notation:
+//! - `m` represents the master key
+//! - `/` separates path components
+//! - Numbers represent child indices
+//! - `'` or `h` suffix indicates hardened derivation
+//!
+//! # Examples
+//!
+//! ```text
+//! m/44'/0'/0'/0/0    - BIP-44 Bitcoin address derivation
+//! m/0                - First normal child
+//! m/0'/1/2'          - Mixed hardened and normal derivation
+//! m/1/2/3/4/5        - Deep normal derivation path
+//! ```
+//!
+//! # Generic Design
+//!
+//! This implementation is intentionally generic and does not enforce any specific
+//! BIP (like BIP-44, BIP-49, BIP-84) semantics. It can represent any valid BIP-32
+//! derivation path. Higher-level libraries or applications can add semantic meaning
+//! to specific path structures.
+
+use crate::ChildNumber;
+
+/// A BIP-32 derivation path.
+///
+/// Represents a sequence of child numbers that specify how to derive a key from
+/// the master key by following the hierarchical tree structure defined in BIP-32.
+///
+/// # Structure
+///
+/// The path is stored as a vector of `ChildNumber` components, where each component
+/// can be either normal (non-hardened) or hardened.
+///
+/// # Depth
+///
+/// - Master key (m): depth 0, no path components
+/// - First child (m/0): depth 1, one path component
+/// - Second level (m/0/1): depth 2, two path components
+/// - Maximum depth: 255 (BIP-32 limitation)
+///
+/// # Examples
+///
+/// ```rust,ignore
+/// use bip32::DerivationPath;
+///
+/// // Parse a BIP-44 path (future functionality)
+/// let path = DerivationPath::from_str("m/44'/0'/0'/0/0")?;
+/// assert_eq!(path.depth(), 5);
+///
+/// // Empty path represents master key
+/// let master_path = DerivationPath::master();
+/// assert_eq!(master_path.depth(), 0);
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DerivationPath {
+    /// The sequence of child numbers from master key to the target key.
+    ///
+    /// An empty vector represents the master key itself (m).
+    /// Each element represents one level of derivation.
+    path: Vec<ChildNumber>,
+}
+
+impl DerivationPath {
+    /// Maximum depth allowed by BIP-32 specification.
+    ///
+    /// This matches the maximum depth enforced by `ExtendedPrivateKey` and
+    /// `ExtendedPublicKey` structures.
+    pub const MAX_DEPTH: u8 = 255;
+
+    /// Creates a new derivation path from a vector of child numbers.
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Vector of child numbers representing the derivation path
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// use bip32::{DerivationPath, ChildNumber};
+    ///
+    /// let path = DerivationPath::new(vec![
+    ///     ChildNumber::Hardened(44),
+    ///     ChildNumber::Hardened(0),
+    ///     ChildNumber::Normal(0),
+    /// ]);
+    /// ```
+    pub fn new(path: Vec<ChildNumber>) -> Self {
+        DerivationPath { path }
+    }
+
+    /// Creates an empty derivation path representing the master key.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// use bip32::DerivationPath;
+    ///
+    /// let master = DerivationPath::master();
+    /// assert_eq!(master.depth(), 0);
+    /// assert!(master.is_master());
+    /// ```
+    pub fn master() -> Self {
+        DerivationPath { path: Vec::new() }
+    }
+
+    /// Returns the depth of this derivation path.
+    ///
+    /// The depth is the number of derivation steps from the master key.
+    /// - Master key (m): depth 0
+    /// - m/0: depth 1
+    /// - m/0/1: depth 2
+    /// - etc.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// use bip32::{DerivationPath, ChildNumber};
+    ///
+    /// let path = DerivationPath::new(vec![
+    ///     ChildNumber::Normal(0),
+    ///     ChildNumber::Normal(1),
+    /// ]);
+    /// assert_eq!(path.depth(), 2);
+    /// ```
+    pub fn depth(&self) -> u8 {
+        self.path.len() as u8
+    }
+
+    /// Returns `true` if this path represents the master key (empty path).
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// use bip32::DerivationPath;
+    ///
+    /// let master = DerivationPath::master();
+    /// assert!(master.is_master());
+    ///
+    /// let child = DerivationPath::new(vec![ChildNumber::Normal(0)]);
+    /// assert!(!child.is_master());
+    /// ```
+    pub fn is_master(&self) -> bool {
+        self.path.is_empty()
+    }
+
+    /// Returns a slice of the child numbers in this path.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// use bip32::{DerivationPath, ChildNumber};
+    ///
+    /// let path = DerivationPath::new(vec![
+    ///     ChildNumber::Hardened(44),
+    ///     ChildNumber::Normal(0),
+    /// ]);
+    ///
+    /// let components = path.as_slice();
+    /// assert_eq!(components.len(), 2);
+    /// ```
+    pub fn as_slice(&self) -> &[ChildNumber] {
+        &self.path
+    }
+
+    /// Returns an iterator over the child numbers in this path.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// use bip32::{DerivationPath, ChildNumber};
+    ///
+    /// let path = DerivationPath::new(vec![
+    ///     ChildNumber::Normal(0),
+    ///     ChildNumber::Normal(1),
+    /// ]);
+    ///
+    /// for child_num in path.iter() {
+    ///     println!("{:?}", child_num);
+    /// }
+    /// ```
+    pub fn iter(&self) -> impl Iterator<Item = &ChildNumber> {
+        self.path.iter()
+    }
+
+    /// Returns the number of child numbers in this path.
+    ///
+    /// This is equivalent to `depth()` but returns `usize` instead of `u8`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// use bip32::DerivationPath;
+    ///
+    /// let path = DerivationPath::new(vec![
+    ///     ChildNumber::Normal(0),
+    ///     ChildNumber::Normal(1),
+    ///     ChildNumber::Normal(2),
+    /// ]);
+    /// assert_eq!(path.len(), 3);
+    /// ```
+    pub fn len(&self) -> usize {
+        self.path.len()
+    }
+
+    /// Returns `true` if the path is empty (represents master key).
+    ///
+    /// This is equivalent to `is_master()`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// use bip32::DerivationPath;
+    ///
+    /// let path = DerivationPath::master();
+    /// assert!(path.is_empty());
+    /// ```
+    pub fn is_empty(&self) -> bool {
+        self.path.is_empty()
+    }
+}

--- a/crates/bip32/src/lib.rs
+++ b/crates/bip32/src/lib.rs
@@ -40,6 +40,8 @@
 
 // Module declarations
 mod chain_code;
+mod child_number;
+mod derivation_path;
 mod error;
 mod extended_private_key;
 mod extended_public_key;
@@ -49,6 +51,8 @@ mod public_key;
 
 // Public re-exports
 pub use chain_code::ChainCode;
+pub use child_number::ChildNumber;
+pub use derivation_path::DerivationPath;
 pub use error::{Error, Result};
 pub use extended_private_key::ExtendedPrivateKey;
 pub use extended_public_key::ExtendedPublicKey;

--- a/docs/implementations/bip32_tasks.md
+++ b/docs/implementations/bip32_tasks.md
@@ -32,7 +32,7 @@ Here's your comprehensive task list organized by phases and priority. Each task 
 - ✅ Task 24: Implement fingerprint calculation methods (TDD)
 
 ## 🛤️ PHASE 4: Derivation Path Parsing (MEDIUM Priority)
-- 🔲 Task 25: Define DerivationPath struct to hold path components
+- ✅ Task 25: Define DerivationPath struct to hold path components
 - 🔲 Task 26: Define ChildNumber enum (Normal(u32), Hardened(u32))
 - 🔲 Task 27: Write tests for ChildNumber hardened/normal conversion
 - 🔲 Task 28: Implement ChildNumber methods (TDD)


### PR DESCRIPTION
- Add DerivationPath to hold BIP-32 path components
- Add ChildNumber enum (Normal/Hardened)
- Implement path depth and iteration methods
- Generic design, no BIP-44 specific logic