### PR TITLE
feat(bip32): add ChildNumber conversion methods (Tasks 27-28)

### DIFF
--- a/crates/bip32/src/child_number.rs
+++ b/crates/bip32/src/child_number.rs
@@ -178,4 +178,473 @@ impl ChildNumber {
     ///
     /// This is `Hardened(2³¹ - 1)` when converted to an index.
     pub const MAX_HARDENED_INDEX: u32 = u32::MAX;
+
+    /// Creates a `ChildNumber` from a raw u32 index.
+    ///
+    /// If the index has the hardened bit set (bit 31), creates a `Hardened` variant.
+    /// Otherwise, creates a `Normal` variant.
+    ///
+    /// # Arguments
+    ///
+    /// * `index` - The raw index value (0 to 2³²-1)
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// use bip32::ChildNumber;
+    ///
+    /// // Normal indices
+    /// let normal_0 = ChildNumber::from_index(0);
+    /// assert_eq!(normal_0, ChildNumber::Normal(0));
+    ///
+    /// let normal_42 = ChildNumber::from_index(42);
+    /// assert_eq!(normal_42, ChildNumber::Normal(42));
+    ///
+    /// // Hardened indices
+    /// let hardened_0 = ChildNumber::from_index(0x80000000);
+    /// assert_eq!(hardened_0, ChildNumber::Hardened(0));
+    ///
+    /// let hardened_44 = ChildNumber::from_index(0x8000002C);  // 2^31 + 44
+    /// assert_eq!(hardened_44, ChildNumber::Hardened(44));
+    /// ```
+    pub fn from_index(index: u32) -> Self {
+        if index & Self::HARDENED_BIT == 0 {
+            // Bit 31 is not set: Normal derivation
+            ChildNumber::Normal(index)
+        } else {
+            // Bit 31 is set: Hardened derivation
+            // Remove the hardened bit to get the base index
+            ChildNumber::Hardened(index & Self::MAX_NORMAL_INDEX)
+        }
+    }
+
+    /// Converts this `ChildNumber` to a raw u32 index.
+    ///
+    /// For `Normal` variants, returns the value as-is.
+    /// For `Hardened` variants, returns the value with the hardened bit set (value + 2³¹).
+    ///
+    /// # Returns
+    ///
+    /// The raw index value that would be used in BIP-32 key derivation.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// use bip32::ChildNumber;
+    ///
+    /// // Normal child numbers
+    /// assert_eq!(ChildNumber::Normal(0).to_index(), 0);
+    /// assert_eq!(ChildNumber::Normal(42).to_index(), 42);
+    ///
+    /// // Hardened child numbers
+    /// assert_eq!(ChildNumber::Hardened(0).to_index(), 0x80000000);
+    /// assert_eq!(ChildNumber::Hardened(44).to_index(), 0x8000002C);
+    /// ```
+    pub fn to_index(self) -> u32 {
+        match self {
+            ChildNumber::Normal(index) => index,
+            ChildNumber::Hardened(index) => index | Self::HARDENED_BIT,
+        }
+    }
+
+    /// Returns `true` if this is a normal (non-hardened) child number.
+    ///
+    /// Normal child numbers allow deriving child public keys from parent public keys
+    /// without needing the private key.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// use bip32::ChildNumber;
+    ///
+    /// assert!(ChildNumber::Normal(0).is_normal());
+    /// assert!(ChildNumber::Normal(42).is_normal());
+    /// assert!(!ChildNumber::Hardened(0).is_normal());
+    /// ```
+    pub fn is_normal(self) -> bool {
+        matches!(self, ChildNumber::Normal(_))
+    }
+
+    /// Returns `true` if this is a hardened child number.
+    ///
+    /// Hardened child numbers require the parent private key for derivation and
+    /// provide better security by preventing public key derivation.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// use bip32::ChildNumber;
+    ///
+    /// assert!(ChildNumber::Hardened(0).is_hardened());
+    /// assert!(ChildNumber::Hardened(44).is_hardened());
+    /// assert!(!ChildNumber::Normal(0).is_hardened());
+    /// ```
+    pub fn is_hardened(self) -> bool {
+        matches!(self, ChildNumber::Hardened(_))
+    }
+
+    /// Returns the base value of this child number (without the hardened bit).
+    ///
+    /// For both `Normal` and `Hardened` variants, this returns the stored index value
+    /// in the range 0 to 2³¹-1.
+    ///
+    /// # Returns
+    ///
+    /// - For `Normal(n)`: returns `n`
+    /// - For `Hardened(n)`: returns `n` (not `n + 2³¹`)
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// use bip32::ChildNumber;
+    ///
+    /// // For normal, value() equals to_index()
+    /// let normal = ChildNumber::Normal(42);
+    /// assert_eq!(normal.value(), 42);
+    /// assert_eq!(normal.value(), normal.to_index());
+    ///
+    /// // For hardened, value() is the base (without hardened bit)
+    /// let hardened = ChildNumber::Hardened(44);
+    /// assert_eq!(hardened.value(), 44);
+    /// assert_eq!(hardened.to_index(), 0x8000002C);  // 2^31 + 44
+    /// ```
+    pub fn value(self) -> u32 {
+        match self {
+            ChildNumber::Normal(value) => value,
+            ChildNumber::Hardened(value) => value,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ========================================================================
+    // Constants Tests
+    // ========================================================================
+
+    #[test]
+    fn test_constants_values() {
+        assert_eq!(ChildNumber::HARDENED_BIT, 0x80000000);
+        assert_eq!(ChildNumber::HARDENED_BIT, 2_147_483_648);
+        
+        assert_eq!(ChildNumber::MAX_NORMAL_INDEX, 0x7FFFFFFF);
+        assert_eq!(ChildNumber::MAX_NORMAL_INDEX, 2_147_483_647);
+        
+        assert_eq!(ChildNumber::MAX_BASE_INDEX, 2_147_483_647);
+        
+        assert_eq!(ChildNumber::MIN_HARDENED_INDEX, 0x80000000);
+        assert_eq!(ChildNumber::MIN_HARDENED_INDEX, 2_147_483_648);
+        
+        assert_eq!(ChildNumber::MAX_HARDENED_INDEX, 0xFFFFFFFF);
+        assert_eq!(ChildNumber::MAX_HARDENED_INDEX, u32::MAX);
+    }
+
+    #[test]
+    fn test_constants_relationships() {
+        // MAX_NORMAL_INDEX is one less than HARDENED_BIT
+        assert_eq!(ChildNumber::MAX_NORMAL_INDEX + 1, ChildNumber::HARDENED_BIT);
+        
+        // MIN_HARDENED_INDEX equals HARDENED_BIT
+        assert_eq!(ChildNumber::MIN_HARDENED_INDEX, ChildNumber::HARDENED_BIT);
+        
+        // MAX_BASE_INDEX equals MAX_NORMAL_INDEX
+        assert_eq!(ChildNumber::MAX_BASE_INDEX, ChildNumber::MAX_NORMAL_INDEX);
+    }
+
+    // ========================================================================
+    // Creation Tests
+    // ========================================================================
+
+    #[test]
+    fn test_normal_creation() {
+        let normal_0 = ChildNumber::Normal(0);
+        assert!(matches!(normal_0, ChildNumber::Normal(0)));
+        
+        let normal_max = ChildNumber::Normal(ChildNumber::MAX_NORMAL_INDEX);
+        assert!(matches!(normal_max, ChildNumber::Normal(_)));
+    }
+
+    #[test]
+    fn test_hardened_creation() {
+        let hardened_0 = ChildNumber::Hardened(0);
+        assert!(matches!(hardened_0, ChildNumber::Hardened(0)));
+        
+        let hardened_44 = ChildNumber::Hardened(44);
+        assert!(matches!(hardened_44, ChildNumber::Hardened(44)));
+        
+        let hardened_max = ChildNumber::Hardened(ChildNumber::MAX_NORMAL_INDEX);
+        assert!(matches!(hardened_max, ChildNumber::Hardened(_)));
+    }
+
+    // ========================================================================
+    // Equality and Comparison Tests
+    // ========================================================================
+
+    #[test]
+    fn test_equality() {
+        assert_eq!(ChildNumber::Normal(0), ChildNumber::Normal(0));
+        assert_eq!(ChildNumber::Normal(42), ChildNumber::Normal(42));
+        assert_eq!(ChildNumber::Hardened(0), ChildNumber::Hardened(0));
+        assert_eq!(ChildNumber::Hardened(44), ChildNumber::Hardened(44));
+    }
+
+    #[test]
+    fn test_inequality() {
+        assert_ne!(ChildNumber::Normal(0), ChildNumber::Normal(1));
+        assert_ne!(ChildNumber::Hardened(0), ChildNumber::Hardened(1));
+        assert_ne!(ChildNumber::Normal(0), ChildNumber::Hardened(0));
+        assert_ne!(ChildNumber::Normal(44), ChildNumber::Hardened(44));
+    }
+
+    #[test]
+    fn test_ordering() {
+        // Normal variants order by their index
+        assert!(ChildNumber::Normal(0) < ChildNumber::Normal(1));
+        assert!(ChildNumber::Normal(1) < ChildNumber::Normal(100));
+        
+        // Hardened variants order by their index
+        assert!(ChildNumber::Hardened(0) < ChildNumber::Hardened(1));
+        assert!(ChildNumber::Hardened(1) < ChildNumber::Hardened(100));
+        
+        // Normal comes before Hardened (enum variant order)
+        assert!(ChildNumber::Normal(0) < ChildNumber::Hardened(0));
+        assert!(ChildNumber::Normal(999) < ChildNumber::Hardened(0));
+    }
+
+    #[test]
+    fn test_clone_and_copy() {
+        let original = ChildNumber::Normal(42);
+        let cloned = original.clone();
+        let copied = original;
+        
+        assert_eq!(original, cloned);
+        assert_eq!(original, copied);
+    }
+
+    #[test]
+    fn test_hash() {
+        use std::collections::HashSet;
+        
+        let mut set = HashSet::new();
+        set.insert(ChildNumber::Normal(0));
+        set.insert(ChildNumber::Normal(1));
+        set.insert(ChildNumber::Hardened(0));
+        
+        assert!(set.contains(&ChildNumber::Normal(0)));
+        assert!(set.contains(&ChildNumber::Hardened(0)));
+        assert!(!set.contains(&ChildNumber::Normal(2)));
+    }
+
+    #[test]
+    fn test_debug_format() {
+        let normal = ChildNumber::Normal(42);
+        let hardened = ChildNumber::Hardened(44);
+        
+        let normal_debug = format!("{:?}", normal);
+        let hardened_debug = format!("{:?}", hardened);
+        
+        assert!(normal_debug.contains("Normal"));
+        assert!(normal_debug.contains("42"));
+        assert!(hardened_debug.contains("Hardened"));
+        assert!(hardened_debug.contains("44"));
+    }
+
+    // ========================================================================
+    // Conversion from u32 Tests (Task 27 - TDD)
+    // ========================================================================
+
+    #[test]
+    fn test_from_u32_normal() {
+        // Normal indices (0 to 2^31-1)
+        let child_0 = ChildNumber::from_index(0);
+        assert_eq!(child_0, ChildNumber::Normal(0));
+        
+        let child_1 = ChildNumber::from_index(1);
+        assert_eq!(child_1, ChildNumber::Normal(1));
+        
+        let child_max = ChildNumber::from_index(ChildNumber::MAX_NORMAL_INDEX);
+        assert_eq!(child_max, ChildNumber::Normal(ChildNumber::MAX_NORMAL_INDEX));
+    }
+
+    #[test]
+    fn test_from_u32_hardened() {
+        // Hardened indices (2^31 to 2^32-1)
+        let child_h0 = ChildNumber::from_index(ChildNumber::HARDENED_BIT);
+        assert_eq!(child_h0, ChildNumber::Hardened(0));
+        
+        let child_h1 = ChildNumber::from_index(ChildNumber::HARDENED_BIT + 1);
+        assert_eq!(child_h1, ChildNumber::Hardened(1));
+        
+        let child_h44 = ChildNumber::from_index(ChildNumber::HARDENED_BIT + 44);
+        assert_eq!(child_h44, ChildNumber::Hardened(44));
+        
+        let child_max = ChildNumber::from_index(u32::MAX);
+        assert_eq!(child_max, ChildNumber::Hardened(ChildNumber::MAX_NORMAL_INDEX));
+    }
+
+    #[test]
+    fn test_from_index_boundary() {
+        // Test boundary between normal and hardened
+        let last_normal = ChildNumber::from_index(0x7FFFFFFF);
+        assert!(matches!(last_normal, ChildNumber::Normal(_)));
+        
+        let first_hardened = ChildNumber::from_index(0x80000000);
+        assert!(matches!(first_hardened, ChildNumber::Hardened(_)));
+    }
+
+    // ========================================================================
+    // Conversion to u32 Tests (Task 27 - TDD)
+    // ========================================================================
+
+    #[test]
+    fn test_to_u32_normal() {
+        assert_eq!(ChildNumber::Normal(0).to_index(), 0);
+        assert_eq!(ChildNumber::Normal(1).to_index(), 1);
+        assert_eq!(ChildNumber::Normal(42).to_index(), 42);
+        assert_eq!(ChildNumber::Normal(ChildNumber::MAX_NORMAL_INDEX).to_index(), 
+                   ChildNumber::MAX_NORMAL_INDEX);
+    }
+
+    #[test]
+    fn test_to_u32_hardened() {
+        assert_eq!(ChildNumber::Hardened(0).to_index(), ChildNumber::HARDENED_BIT);
+        assert_eq!(ChildNumber::Hardened(1).to_index(), ChildNumber::HARDENED_BIT + 1);
+        assert_eq!(ChildNumber::Hardened(44).to_index(), ChildNumber::HARDENED_BIT + 44);
+        assert_eq!(ChildNumber::Hardened(ChildNumber::MAX_NORMAL_INDEX).to_index(), u32::MAX);
+    }
+
+    #[test]
+    fn test_roundtrip_conversion() {
+        // Normal values
+        for i in [0, 1, 42, 100, ChildNumber::MAX_NORMAL_INDEX] {
+            let child = ChildNumber::from_index(i);
+            assert_eq!(child.to_index(), i);
+        }
+        
+        // Hardened values
+        for i in [
+            ChildNumber::HARDENED_BIT,
+            ChildNumber::HARDENED_BIT + 1,
+            ChildNumber::HARDENED_BIT + 44,
+            u32::MAX,
+        ] {
+            let child = ChildNumber::from_index(i);
+            assert_eq!(child.to_index(), i);
+        }
+    }
+
+    // ========================================================================
+    // Query Methods Tests (Task 27 - TDD)
+    // ========================================================================
+
+    #[test]
+    fn test_is_normal() {
+        assert!(ChildNumber::Normal(0).is_normal());
+        assert!(ChildNumber::Normal(42).is_normal());
+        assert!(ChildNumber::Normal(ChildNumber::MAX_NORMAL_INDEX).is_normal());
+        
+        assert!(!ChildNumber::Hardened(0).is_normal());
+        assert!(!ChildNumber::Hardened(44).is_normal());
+    }
+
+    #[test]
+    fn test_is_hardened() {
+        assert!(!ChildNumber::Normal(0).is_hardened());
+        assert!(!ChildNumber::Normal(42).is_hardened());
+        
+        assert!(ChildNumber::Hardened(0).is_hardened());
+        assert!(ChildNumber::Hardened(44).is_hardened());
+        assert!(ChildNumber::Hardened(ChildNumber::MAX_NORMAL_INDEX).is_hardened());
+    }
+
+    #[test]
+    fn test_is_normal_and_hardened_mutually_exclusive() {
+        let normal = ChildNumber::Normal(42);
+        assert!(normal.is_normal());
+        assert!(!normal.is_hardened());
+        
+        let hardened = ChildNumber::Hardened(42);
+        assert!(!hardened.is_normal());
+        assert!(hardened.is_hardened());
+    }
+
+    // ========================================================================
+    // Value Extraction Tests (Task 27 - TDD)
+    // ========================================================================
+
+    #[test]
+    fn test_value_normal() {
+        assert_eq!(ChildNumber::Normal(0).value(), 0);
+        assert_eq!(ChildNumber::Normal(42).value(), 42);
+        assert_eq!(ChildNumber::Normal(ChildNumber::MAX_NORMAL_INDEX).value(), 
+                   ChildNumber::MAX_NORMAL_INDEX);
+    }
+
+    #[test]
+    fn test_value_hardened() {
+        // value() returns the stored value (without hardened bit)
+        assert_eq!(ChildNumber::Hardened(0).value(), 0);
+        assert_eq!(ChildNumber::Hardened(44).value(), 44);
+        assert_eq!(ChildNumber::Hardened(ChildNumber::MAX_NORMAL_INDEX).value(), 
+                   ChildNumber::MAX_NORMAL_INDEX);
+    }
+
+    #[test]
+    fn test_value_vs_to_index() {
+        // For Normal: value() == to_index()
+        let normal = ChildNumber::Normal(42);
+        assert_eq!(normal.value(), normal.to_index());
+        
+        // For Hardened: value() != to_index() (to_index adds HARDENED_BIT)
+        let hardened = ChildNumber::Hardened(44);
+        assert_eq!(hardened.value(), 44);
+        assert_eq!(hardened.to_index(), ChildNumber::HARDENED_BIT + 44);
+        assert_ne!(hardened.value(), hardened.to_index());
+    }
+
+    // ========================================================================
+    // BIP-44 Common Values Tests (Task 27 - TDD)
+    // ========================================================================
+
+    #[test]
+    fn test_bip44_purpose() {
+        // BIP-44 uses purpose = 44'
+        let purpose = ChildNumber::Hardened(44);
+        assert_eq!(purpose.to_index(), 0x8000002C); // 2^31 + 44
+        assert!(purpose.is_hardened());
+    }
+
+    #[test]
+    fn test_bip44_bitcoin_coin_type() {
+        // Bitcoin coin_type = 0'
+        let coin_type = ChildNumber::Hardened(0);
+        assert_eq!(coin_type.to_index(), 0x80000000); // 2^31 + 0
+        assert!(coin_type.is_hardened());
+    }
+
+    #[test]
+    fn test_bip44_first_account() {
+        // First account = 0'
+        let account = ChildNumber::Hardened(0);
+        assert_eq!(account.value(), 0);
+        assert!(account.is_hardened());
+    }
+
+    #[test]
+    fn test_bip44_external_chain() {
+        // External chain (receiving addresses) = 0 (normal)
+        let chain = ChildNumber::Normal(0);
+        assert_eq!(chain.to_index(), 0);
+        assert!(chain.is_normal());
+    }
+
+    #[test]
+    fn test_bip44_internal_chain() {
+        // Internal chain (change addresses) = 1 (normal)
+        let chain = ChildNumber::Normal(1);
+        assert_eq!(chain.to_index(), 1);
+        assert!(chain.is_normal());
+    }
 }

--- a/docs/implementations/bip32_tasks.md
+++ b/docs/implementations/bip32_tasks.md
@@ -34,8 +34,8 @@ Here's your comprehensive task list organized by phases and priority. Each task 
 ## 🛤️ PHASE 4: Derivation Path Parsing (MEDIUM Priority)
 - ✅ Task 25: Define DerivationPath struct to hold path components
 - ✅ Task 26: Define ChildNumber enum (Normal(u32), Hardened(u32))
-- 🔲 Task 27: Write tests for ChildNumber hardened/normal conversion
-- 🔲 Task 28: Implement ChildNumber methods (TDD)
+- ✅ Task 27: Write tests for ChildNumber hardened/normal conversion
+- ✅ Task 28: Implement ChildNumber methods (TDD)
 - 🔲 Task 29: Write tests for DerivationPath parsing (e.g., "m/44'/0'/0'/0/0")
 - 🔲 Task 30: Implement DerivationPath::from_str() parser (TDD)
 - 🔲 Task 31: Write tests for DerivationPath validation


### PR DESCRIPTION
Implement TDD for ChildNumber with 27 tests and 5 methods:
- from_index/to_index: u32 ↔ ChildNumber conversion
- is_normal/is_hardened: type queries
- value: extract base value

All 172 tests passing (145 existing + 27 new)