### PR TITLE
feat(bip32): implement DerivationPath validation (Tasks 31-32)

### DIFF
--- a/docs/implementations/bip32_tasks.md
+++ b/docs/implementations/bip32_tasks.md
@@ -38,8 +38,8 @@ Here's your comprehensive task list organized by phases and priority. Each task 
 - ✅ Task 28: Implement ChildNumber methods (TDD)
 - ✅ Task 29: Write tests for DerivationPath parsing (e.g., "m/44'/0'/0'/0/0")
 - ✅ Task 30: Implement DerivationPath::from_str() parser (TDD)
-- 🔲 Task 31: Write tests for DerivationPath validation
-- 🔲 Task 32: Implement DerivationPath validation methods (TDD)
+- ✅ Task 31: Write tests for DerivationPath validation
+- ✅ Task 32: Implement DerivationPath validation methods (TDD)
 
 ## 🔄 PHASE 5: Child Key Derivation (MEDIUM → HIGH Priority)
 - 🔲 Task 33: Write tests for ExtendedPrivateKey::derive_child() (single step)


### PR DESCRIPTION
Add 11 validation and navigation methods with 16 tests:
- Path security: contains_hardened(), is_public_derivable()
- Navigation: parent(), extend(), child_number_at()
- Analysis: hardened_prefix_length(), normal_suffix_length()
- Comparison: starts_with()

Enables watch-only wallets and BIP-44 path analysis.

All 224 tests passing.