### PR TITLE
feat(bip32): add derive_path() for multi-level derivation

### DIFF
--- a/docs/implementations/bip32_tasks.md
+++ b/docs/implementations/bip32_tasks.md
@@ -48,8 +48,8 @@ Here's your comprehensive task list organized by phases and priority. Each task 
 - ✅ Task 36: Implement hardened derivation logic (covered in Task 34)
 - ✅ Task 37: Write tests for ExtendedPublicKey::derive_child() (normal only)
 - ✅ Task 38: Implement ExtendedPublicKey::derive_child() (TDD)
-- 🔲 Task 39: Write tests for ExtendedPrivateKey::derive_path() (multi-level)
-- 🔲 Task 40: Implement ExtendedPrivateKey::derive_path() (TDD)
+- ✅ Task 39: Write tests for ExtendedPrivateKey::derive_path() (multi-level)
+- ✅ Task 40: Implement ExtendedPrivateKey::derive_path() (TDD)
 - 🔲 Task 41: Write tests for ExtendedPublicKey::derive_path() (normal only)
 - 🔲 Task 42: Implement ExtendedPublicKey::derive_path() (TDD)
 


### PR DESCRIPTION
Implement path-based key derivation using DerivationPath strings.

- Convenient wrapper over derive_child() iterations
- BIP-44/49/84 path support validated
- 14 comprehensive tests

Usage: master.derive_path(&"m/44'/0'/0'/0/0".parse()?)

All 264 tests passing