### PR TITLE
feat(bip32): implement xprv/tprv serialization

### DIFF
--- a/docs/implementations/bip32_tasks.md
+++ b/docs/implementations/bip32_tasks.md
@@ -54,8 +54,8 @@ Here's your comprehensive task list organized by phases and priority. Each task 
 - ✅ Task 42: Implement ExtendedPublicKey::derive_path() (TDD)
 
 ## 📦 PHASE 6: Serialization & Deserialization (MEDIUM Priority)
-- 🔲 Task 43: Write tests for ExtendedPrivateKey Base58Check serialization (xprv)
-- 🔲 Task 44: Implement ExtendedPrivateKey::to_string() serialization (TDD)
+- ✅ Task 43: Write tests for ExtendedPrivateKey Base58Check serialization (xprv)
+- ✅ Task 44: Implement ExtendedPrivateKey::to_string() serialization (TDD)
 - 🔲 Task 45: Write tests for ExtendedPrivateKey Base58Check deserialization
 - 🔲 Task 46: Implement ExtendedPrivateKey::from_str() deserialization (TDD)
 - 🔲 Task 47: Write tests for ExtendedPublicKey Base58Check serialization (xpub)


### PR DESCRIPTION
Add Base58Check encoding for ExtendedPrivateKey per BIP-32 spec.

- 82-byte format: version(4) + depth(1) + fingerprint(4) + child(4) + chain(32) + 0x00+key(33) + checksum(4)
- Network prefixes: xprv/tprv
- Validated against BIP-32 test vectors

Enables cross-wallet compatibility

All 290 tests passing