### PR TITLE
feat(bip32): add derive_keypair_from_path() utility

### DIFF
--- a/docs/implementations/bip32_tasks.md
+++ b/docs/implementations/bip32_tasks.md
@@ -76,8 +76,8 @@ Here's your comprehensive task list organized by phases and priority. Each task 
 ## 🎨 PHASE 8: Utility Functions & Convenience Methods (LOW Priority)
 - ✅ Task 59: Write tests for keypair generation helper
 - ✅ Task 60: Implement generate_master_keypair() utility (TDD)
-- 🔲 Task 61: Write tests for derive_keypair_from_path() helper
-- 🔲 Task 62: Implement derive_keypair_from_path() utility (TDD)
+- ✅ Task 61: Write tests for derive_keypair_from_path() helper
+- ✅ Task 62: Implement derive_keypair_from_path() utility (TDD)
 
 ## 🛡️ PHASE 9: Security & Edge Cases (LOW → MEDIUM Priority)
 - 🔲 Task 63: Write tests for invalid curve points detection


### PR DESCRIPTION
Add convenience function to derive both keys from a path.

New utility:
- derive_keypair_from_path(master_key, path) → (priv, pub)
- Reduces 2-line pattern to 1-line call
- 15 tests + 3 doctests
- 100+ lines documentation

Example:
  let (priv_key, pub_key) = derive_keypair_from_path(&master, &path)?;

Use cases:
- BIP-44 account derivation (m/44'/0'/0')
- BIP-44 address derivation (m/44'/0'/0'/0/0)
- Watch-only wallet workflows

All 379 tests passing