### PR TITLE
feat(bip32): add maximum depth validation

### DIFF
--- a/docs/implementations/bip32_tasks.md
+++ b/docs/implementations/bip32_tasks.md
@@ -86,8 +86,8 @@ Here's your comprehensive task list organized by phases and priority. Each task 
 - ✅ Task 66: Implement key range validation (TDD)
 - ✅ Task 67: Write tests for zero keys rejection
 - ✅ Task 68: Implement zero key detection and error handling (TDD)
-- 🔲 Task 69: Add tests for maximum derivation depth limits
-- 🔲 Task 70: Implement depth validation (TDD)
+- ✅ Task 69: Add tests for maximum derivation depth limits
+- ✅ Task 70: Implement depth validation (TDD)
 
 ## 🧪 PHASE 10: Test Vectors & Compliance (MEDIUM Priority)
 - 🔲 Task 71: Import BIP32 official test vectors


### PR DESCRIPTION
Implement depth limit validation per BIP-32 specification.

BIP-32 depth specification:
- Single byte field limits depth to 255
- Valid range: 0 ≤ depth ≤ 255 (256 total levels)
- Depth 255 cannot derive children

Testing (13 new tests):
- Boundary values: 0, 1, 10, 100, 250, 253, 254, 255
- Keys at 255 cannot derive (MaxDepthExceeded error)
- Keys at 254 can derive to 255
- Serialization preserves depth 255
- Public keys also respect max depth

Documentation:
- 50+ lines explaining depth limits
- BIP-44/49/84 context (depth 5 in practice)
- MAX_DEPTH constant documented
- derive_child() depth validation section

Practical usage:
- BIP-44/49/84 use depth 5
- 255 limit provides ample headroom

All 438 tests passing