### PR TITLE
fix: GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        rust: [stable, 1.70.0]
+        rust: [stable, 1.80.0]
     steps:
       - uses: actions/checkout@v4
       

--- a/crates/bip32/Cargo.toml
+++ b/crates/bip32/Cargo.toml
@@ -2,6 +2,7 @@
 name = "khodpay-bip32"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.80"
 authors = ["KhodPay Team"]
 license = "MIT OR Apache-2.0"
 description = "Production-ready Rust implementation of BIP32 hierarchical deterministic wallets"
@@ -11,7 +12,6 @@ homepage = "https://github.com/khodpay/khodpay-wallet"
 readme = "README.md"
 keywords = ["bitcoin", "cryptocurrency", "bip32", "hd-wallet", "wallet"]
 categories = ["cryptography", "no-std"]
-rust-version = "1.70"
 
 [dependencies]
 khodpay-bip39 = { version = "0.1.0", path = "../bip39" }

--- a/crates/bip39/Cargo.toml
+++ b/crates/bip39/Cargo.toml
@@ -2,6 +2,7 @@
 name = "khodpay-bip39"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.80"
 authors = ["KhodPay Team"]
 license = "MIT OR Apache-2.0"
 description = "Production-ready Rust implementation of BIP39 mnemonic code for cryptocurrency wallets"
@@ -11,7 +12,6 @@ homepage = "https://github.com/khodpay/khodpay-wallet"
 readme = "README.md"
 keywords = ["bitcoin", "cryptocurrency", "bip39", "mnemonic", "wallet"]
 categories = ["cryptography", "no-std"]
-rust-version = "1.70"
 
 [dependencies]
 bip39-upstream = { package = "bip39", version = "2.0", features = ["all-languages"] }


### PR DESCRIPTION
- Fix GitHub Actions CI for path dependencies
- Add lockfile generation and proper caching
- Change branch names: develop → dev
- Pin tool versions for reproducibility