### PR TITLE
fix: resolve CI blockers and all clippy warnings

### DIFF
--- a/crates/bip32/benches/key_derivation.rs
+++ b/crates/bip32/benches/key_derivation.rs
@@ -16,14 +16,15 @@ use std::str::FromStr;
 
 /// Setup function to create a master key for benchmarking
 fn setup_master_key() -> ExtendedPrivateKey {
-    let seed = b"benchmark-seed-for-performance-testing-only-not-for-production-use!!";
+    // Use a 64-byte seed (maximum valid length)
+    let seed = b"benchmark-seed-for-testing-only-not-for-production-use-64bytes!";
     ExtendedPrivateKey::from_seed(seed, Network::BitcoinMainnet)
         .expect("Failed to create master key")
 }
 
 /// Benchmark master key generation from seed
 fn bench_master_key_from_seed(c: &mut Criterion) {
-    let seed = b"benchmark-seed-for-performance-testing-only-not-for-production-use!!";
+    let seed = b"benchmark-seed-for-testing-only-not-for-production-use-64bytes!";
 
     c.bench_function("master_key_from_seed", |b| {
         b.iter(|| {

--- a/crates/bip32/benches/serialization.rs
+++ b/crates/bip32/benches/serialization.rs
@@ -16,7 +16,7 @@ use std::str::FromStr;
 
 /// Setup function to create keys at various depths for benchmarking
 fn setup_keys_at_depths() -> Vec<(String, ExtendedPrivateKey)> {
-    let seed = b"benchmark-seed-for-serialization-testing-only-not-for-production!!";
+    let seed = b"benchmark-seed-for-serialization-testing-64bytes-max!!!!!!!";
     let master = ExtendedPrivateKey::from_seed(seed, Network::BitcoinMainnet)
         .expect("Failed to create master key");
 
@@ -126,7 +126,7 @@ fn bench_xpub_deserialization(c: &mut Criterion) {
 
 /// Benchmark serialization roundtrip (serialize + deserialize)
 fn bench_xprv_roundtrip(c: &mut Criterion) {
-    let seed = b"benchmark-seed-for-serialization-testing-only-not-for-production!!";
+    let seed = b"benchmark-seed-for-serialization-testing-64bytes-max!!!!!!!";
     let master = ExtendedPrivateKey::from_seed(seed, Network::BitcoinMainnet).unwrap();
 
     c.bench_function("xprv_roundtrip_master", |b| {
@@ -150,7 +150,7 @@ fn bench_xprv_roundtrip(c: &mut Criterion) {
 
 /// Benchmark xpub roundtrip
 fn bench_xpub_roundtrip(c: &mut Criterion) {
-    let seed = b"benchmark-seed-for-serialization-testing-only-not-for-production!!";
+    let seed = b"benchmark-seed-for-serialization-testing-64bytes-max!!!!!!!";
     let master = ExtendedPrivateKey::from_seed(seed, Network::BitcoinMainnet).unwrap();
     let master_pub = master.to_extended_public_key();
 
@@ -176,7 +176,7 @@ fn bench_xpub_roundtrip(c: &mut Criterion) {
 
 /// Benchmark Base58Check encoding/decoding performance
 fn bench_base58_operations(c: &mut Criterion) {
-    let seed = b"benchmark-seed-for-serialization-testing-only-not-for-production!!";
+    let seed = b"benchmark-seed-for-serialization-testing-64bytes-max!!!!!!!";
     let master = ExtendedPrivateKey::from_seed(seed, Network::BitcoinMainnet).unwrap();
     let xprv_string = master.to_string();
 
@@ -199,7 +199,7 @@ fn bench_base58_operations(c: &mut Criterion) {
 
 /// Benchmark network-specific serialization
 fn bench_network_serialization(c: &mut Criterion) {
-    let seed = b"benchmark-seed-for-serialization-testing-only-not-for-production!!";
+    let seed = b"benchmark-seed-for-serialization-testing-64bytes-max!!!!!!!";
 
     let mut group = c.benchmark_group("network_serialization");
 
@@ -224,7 +224,7 @@ fn bench_network_serialization(c: &mut Criterion) {
 
 /// Benchmark bulk serialization (e.g., for batch operations)
 fn bench_bulk_serialization(c: &mut Criterion) {
-    let seed = b"benchmark-seed-for-serialization-testing-only-not-for-production!!";
+    let seed = b"benchmark-seed-for-serialization-testing-64bytes-max!!!!!!!";
     let master = ExtendedPrivateKey::from_seed(seed, Network::BitcoinMainnet).unwrap();
     let account_path = DerivationPath::from_str("m/44'/0'/0'/0").unwrap();
     let account = master.derive_path(&account_path).unwrap();
@@ -245,7 +245,7 @@ fn bench_bulk_serialization(c: &mut Criterion) {
 
 /// Benchmark bulk deserialization
 fn bench_bulk_deserialization(c: &mut Criterion) {
-    let seed = b"benchmark-seed-for-serialization-testing-only-not-for-production!!";
+    let seed = b"benchmark-seed-for-serialization-testing-64bytes-max!!!!!!!";
     let master = ExtendedPrivateKey::from_seed(seed, Network::BitcoinMainnet).unwrap();
     let account_path = DerivationPath::from_str("m/44'/0'/0'/0").unwrap();
     let account = master.derive_path(&account_path).unwrap();
@@ -271,7 +271,7 @@ fn bench_bulk_deserialization(c: &mut Criterion) {
 
 /// Benchmark Display trait implementation
 fn bench_display_trait(c: &mut Criterion) {
-    let seed = b"benchmark-seed-for-serialization-testing-only-not-for-production!!";
+    let seed = b"benchmark-seed-for-serialization-testing-64bytes-max!!!!!!!";
     let master = ExtendedPrivateKey::from_seed(seed, Network::BitcoinMainnet).unwrap();
 
     c.bench_function("display_trait_xprv", |b| {
@@ -290,7 +290,7 @@ fn bench_display_trait(c: &mut Criterion) {
 
 /// Benchmark FromStr trait implementation
 fn bench_fromstr_trait(c: &mut Criterion) {
-    let seed = b"benchmark-seed-for-serialization-testing-only-not-for-production!!";
+    let seed = b"benchmark-seed-for-serialization-testing-64bytes-max!!!!!!!";
     let master = ExtendedPrivateKey::from_seed(seed, Network::BitcoinMainnet).unwrap();
     let xprv_string = master.to_string();
     let xpub_string = master.to_extended_public_key().to_string();

--- a/crates/bip32/src/chain_code.rs
+++ b/crates/bip32/src/chain_code.rs
@@ -415,7 +415,7 @@ mod tests {
 
         // This test mainly serves as documentation that ChainCode
         // implements ZeroizeOnDrop and will be zeroized on drop.
-        assert_eq!(ptr as usize > 0, true); // Pointer was valid
+        assert!(ptr as usize > 0); // Pointer was valid
     }
 
     #[test]

--- a/crates/bip32/src/child_number.rs
+++ b/crates/bip32/src/child_number.rs
@@ -446,7 +446,7 @@ mod tests {
     #[test]
     fn test_clone_and_copy() {
         let original = ChildNumber::Normal(42);
-        let cloned = original.clone();
+        let cloned = original;
         let copied = original;
 
         assert_eq!(original, cloned);

--- a/crates/bip32/src/derivation_path.rs
+++ b/crates/bip32/src/derivation_path.rs
@@ -353,7 +353,7 @@ impl DerivationPath {
     pub fn is_hardened_at(&self, index: usize) -> bool {
         self.path
             .get(index)
-            .map_or(false, |child| child.is_hardened())
+            .is_some_and(|child| child.is_hardened())
     }
 
     /// Returns a reference to the child number at the given index.
@@ -614,10 +614,10 @@ fn parse_child_number(component: &str, full_path: &str) -> Result<ChildNumber> {
     }
 
     // Check for hardened suffix (supports ', h, or H)
-    let (is_hardened, number_str) = if component.ends_with('\'') {
-        (true, &component[..component.len() - 1])
-    } else if component.ends_with('h') || component.ends_with('H') {
-        (true, &component[..component.len() - 1])
+    let (is_hardened, number_str) = if let Some(stripped) = component.strip_suffix('\'') {
+        (true, stripped)
+    } else if let Some(stripped) = component.strip_suffix(['h', 'H']) {
+        (true, stripped)
     } else {
         (false, component)
     };

--- a/crates/bip32/src/extended_private_key.rs
+++ b/crates/bip32/src/extended_private_key.rs
@@ -148,7 +148,7 @@ impl ExtendedPrivateKey {
     /// # Arguments
     ///
     /// * `seed` - A cryptographic seed, typically 128-512 bits (16-64 bytes).
-    ///            Usually derived from a BIP-39 mnemonic phrase.
+    ///   Usually derived from a BIP-39 mnemonic phrase.
     /// * `network` - The network for this key (Bitcoin mainnet, testnet, etc.)
     ///
     /// # Returns
@@ -447,10 +447,10 @@ impl ExtendedPrivateKey {
         let public_key_bytes = public_key.to_bytes();
 
         // Step 1: SHA256
-        let sha256_hash = Sha256::digest(&public_key_bytes);
+        let sha256_hash = Sha256::digest(public_key_bytes);
 
         // Step 2: RIPEMD160
-        let ripemd160_hash = Ripemd160::digest(&sha256_hash);
+        let ripemd160_hash = Ripemd160::digest(sha256_hash);
 
         // Step 3: Take first 4 bytes
         let mut fingerprint = [0u8; 4];
@@ -693,7 +693,7 @@ impl std::fmt::Display for ExtendedPrivateKey {
 
         // 7. Compute checksum: first 4 bytes of SHA256(SHA256(data))
         let hash1 = Sha256::digest(&data);
-        let hash2 = Sha256::digest(&hash1);
+        let hash2 = Sha256::digest(hash1);
         let checksum = &hash2[0..4];
 
         // 8. Append checksum to get 82 bytes total
@@ -758,7 +758,7 @@ impl std::str::FromStr for ExtendedPrivateKey {
         let checksum = &data[78..82];
 
         let hash1 = Sha256::digest(payload);
-        let hash2 = Sha256::digest(&hash1);
+        let hash2 = Sha256::digest(hash1);
         let expected_checksum = &hash2[0..4];
 
         if checksum != expected_checksum {

--- a/crates/bip32/src/extended_public_key.rs
+++ b/crates/bip32/src/extended_public_key.rs
@@ -236,10 +236,10 @@ impl ExtendedPublicKey {
         let public_key_bytes = self.public_key.to_bytes();
 
         // Step 1: SHA256
-        let sha256_hash = Sha256::digest(&public_key_bytes);
+        let sha256_hash = Sha256::digest(public_key_bytes);
 
         // Step 2: RIPEMD160
-        let ripemd160_hash = Ripemd160::digest(&sha256_hash);
+        let ripemd160_hash = Ripemd160::digest(sha256_hash);
 
         // Step 3: Take first 4 bytes
         let mut fingerprint = [0u8; 4];
@@ -457,7 +457,7 @@ impl std::fmt::Display for ExtendedPublicKey {
 
         // 7. Compute checksum: first 4 bytes of SHA256(SHA256(data))
         let hash1 = Sha256::digest(&data);
-        let hash2 = Sha256::digest(&hash1);
+        let hash2 = Sha256::digest(hash1);
         let checksum = &hash2[0..4];
 
         // 8. Append checksum to get 82 bytes total
@@ -535,7 +535,7 @@ impl std::str::FromStr for ExtendedPublicKey {
         let checksum = &data[78..82];
 
         let hash1 = Sha256::digest(payload);
-        let hash2 = Sha256::digest(&hash1);
+        let hash2 = Sha256::digest(hash1);
         let expected_checksum = &hash2[0..4];
 
         if checksum != expected_checksum {

--- a/crates/bip32/src/network.rs
+++ b/crates/bip32/src/network.rs
@@ -268,13 +268,7 @@ impl Network {
         // Iterate through all network variants
         const NETWORKS: [Network; 2] = [Network::BitcoinMainnet, Network::BitcoinTestnet];
 
-        for network in NETWORKS {
-            if network.xprv_version() == version {
-                return Some(network);
-            }
-        }
-
-        None
+        NETWORKS.into_iter().find(|&network| network.xprv_version() == version)
     }
 
     /// Attempts to identify the network from extended public key version bytes.
@@ -305,13 +299,7 @@ impl Network {
         // Iterate through all network variants
         const NETWORKS: [Network; 2] = [Network::BitcoinMainnet, Network::BitcoinTestnet];
 
-        for network in NETWORKS {
-            if network.xpub_version() == version {
-                return Some(network);
-            }
-        }
-
-        None
+        NETWORKS.into_iter().find(|&network| network.xpub_version() == version)
     }
 }
 
@@ -377,7 +365,7 @@ mod tests {
     fn test_key_type_clone_and_copy() {
         let key_type1 = KeyType::Private;
         let key_type2 = key_type1; // Copy
-        let key_type3 = key_type1.clone(); // Clone
+        let key_type3 = key_type1; // Clone
 
         assert_eq!(key_type1, key_type2);
         assert_eq!(key_type1, key_type3);
@@ -472,7 +460,7 @@ mod tests {
     fn test_clone_and_copy() {
         let network1 = Network::BitcoinMainnet;
         let network2 = network1; // Copy
-        let network3 = network1.clone(); // Clone
+        let network3 = network1; // Clone
 
         assert_eq!(network1, network2);
         assert_eq!(network1, network3);

--- a/crates/bip32/src/private_key.rs
+++ b/crates/bip32/src/private_key.rs
@@ -855,7 +855,7 @@ mod tests {
 
         // Should be able to get public key
         let public_key = private_key.public_key();
-        assert!(public_key.serialize().len() > 0);
+        assert!(!public_key.serialize().is_empty());
 
         // Should be able to get secret key reference
         let secret_key = private_key.secret_key();

--- a/crates/bip32/src/public_key.rs
+++ b/crates/bip32/src/public_key.rs
@@ -791,7 +791,7 @@ mod tests {
         if result.is_ok() {
             // If this pattern happens to be valid, that's fine - secp256k1 accepted it
             // The important thing is we don't crash or behave incorrectly
-            assert!(true);
+            // Test passes - no assertion needed
         } else {
             // If it's invalid, verify we get the right error
             assert!(matches!(

--- a/crates/bip32/tests/test_vectors.rs
+++ b/crates/bip32/tests/test_vectors.rs
@@ -930,12 +930,12 @@ mod tests {
         let mut successful_derivations = 0;
 
         for test_vector in all_test_vectors() {
-            let seed = hex_to_bytes(test_vector.seed_hex).expect(&format!(
+            let seed = hex_to_bytes(test_vector.seed_hex).unwrap_or_else(|_| panic!(
                 "Failed to decode seed for {}",
                 test_vector.description
             ));
             let master =
-                ExtendedPrivateKey::from_seed(&seed, Network::BitcoinMainnet).expect(&format!(
+                ExtendedPrivateKey::from_seed(&seed, Network::BitcoinMainnet).unwrap_or_else(|_| panic!(
                     "Failed to create master key for {}",
                     test_vector.description
                 ));
@@ -945,12 +945,12 @@ mod tests {
 
                 // Parse path
                 let path = DerivationPath::from_str(step.path)
-                    .expect(&format!("Failed to parse path {}", step.path));
+                    .unwrap_or_else(|_| panic!("Failed to parse path {}", step.path));
 
                 // Derive key
                 let derived = master
                     .derive_path(&path)
-                    .expect(&format!("Failed to derive path {}", step.path));
+                    .unwrap_or_else(|_| panic!("Failed to derive path {}", step.path));
 
                 // Verify serialization matches
                 assert_eq!(
@@ -1042,7 +1042,7 @@ mod tests {
         for test_vector in all_test_vectors() {
             for step in test_vector.derivations {
                 // Deserialize from string
-                let deserialized = ExtendedPrivateKey::from_str(step.ext_prv).expect(&format!(
+                let deserialized = ExtendedPrivateKey::from_str(step.ext_prv).unwrap_or_else(|_| panic!(
                     "Failed to deserialize xprv for path {}",
                     step.path
                 ));
@@ -1065,7 +1065,7 @@ mod tests {
         for test_vector in all_test_vectors() {
             for step in test_vector.derivations {
                 // Deserialize from string
-                let deserialized = ExtendedPublicKey::from_str(step.ext_pub).expect(&format!(
+                let deserialized = ExtendedPublicKey::from_str(step.ext_pub).unwrap_or_else(|_| panic!(
                     "Failed to deserialize xpub for path {}",
                     step.path
                 ));
@@ -1349,13 +1349,13 @@ mod tests {
                 }
 
                 // Test xprv deserialization
-                let _ = ExtendedPrivateKey::from_str(step.ext_prv).expect(&format!(
+                let _ = ExtendedPrivateKey::from_str(step.ext_prv).unwrap_or_else(|_| panic!(
                     "Failed to deserialize xprv for path {}",
                     step.path
                 ));
 
                 // Test xpub deserialization
-                let _ = ExtendedPublicKey::from_str(step.ext_pub).expect(&format!(
+                let _ = ExtendedPublicKey::from_str(step.ext_pub).unwrap_or_else(|_| panic!(
                     "Failed to deserialize xpub for path {}",
                     step.path
                 ));
@@ -1427,10 +1427,10 @@ mod tests {
 
         for (xprv_str, xpub_str) in test_cases {
             let prv = ExtendedPrivateKey::from_str(xprv_str)
-                .expect(&format!("Failed to deserialize xprv: {}", xprv_str));
+                .unwrap_or_else(|_| panic!("Failed to deserialize xprv: {}", xprv_str));
             let pub_from_prv = prv.to_extended_public_key();
             let pub_direct = ExtendedPublicKey::from_str(xpub_str)
-                .expect(&format!("Failed to deserialize xpub: {}", xpub_str));
+                .unwrap_or_else(|_| panic!("Failed to deserialize xpub: {}", xpub_str));
 
             // Verify public key derived from private matches
             assert_eq!(
@@ -1677,11 +1677,11 @@ mod tests {
 
         for path_str in test_paths {
             let path = DerivationPath::from_str(path_str)
-                .expect(&format!("Failed to parse BIP44 path: {}", path_str));
+                .unwrap_or_else(|_| panic!("Failed to parse BIP44 path: {}", path_str));
 
             let derived = master
                 .derive_path(&path)
-                .expect(&format!("Failed to derive BIP44 path: {}", path_str));
+                .unwrap_or_else(|_| panic!("Failed to derive BIP44 path: {}", path_str));
 
             // Verify key is valid
             assert!(derived.to_string().starts_with("xprv"));

--- a/crates/bip39/src/language.rs
+++ b/crates/bip39/src/language.rs
@@ -164,7 +164,7 @@ impl Language {
     /// 
     /// With the `all-languages` feature enabled, all BIP39 standard languages
     /// are now properly supported and mapped to their upstream variants.
-    pub(crate) const fn to_upstream(&self) -> bip39_upstream::Language {
+    pub(crate) const fn to_upstream(self) -> bip39_upstream::Language {
         match self {
             Language::English => bip39_upstream::Language::English,
             Language::Japanese => bip39_upstream::Language::Japanese,

--- a/crates/bip39/src/mnemonic.rs
+++ b/crates/bip39/src/mnemonic.rs
@@ -25,7 +25,6 @@
 //! ```
 
 use crate::{Language, WordCount};
-use bip39_upstream;
 
 /// A BIP39 mnemonic phrase with associated metadata.
 ///
@@ -790,7 +789,7 @@ mod tests {
     fn test_from_phrase_all_languages() {
         // Test that from_phrase works with different languages
         // Note: Some languages share words, so we test key languages only
-        let test_languages = vec![
+        let test_languages = [
             Language::English,
             Language::Japanese,
             Language::Korean,

--- a/crates/bip39/src/utils.rs
+++ b/crates/bip39/src/utils.rs
@@ -853,7 +853,7 @@ mod tests {
     #[test]
     fn test_phrase_to_seed_all_word_counts() {
         // Test that all valid word counts produce 64-byte seeds
-        let test_cases = vec![
+        let test_cases = [
             (12, vec![0u8; 16]),  // 12 words = 128 bits entropy
             (15, vec![0u8; 20]),  // 15 words = 160 bits entropy
             (18, vec![0u8; 24]),  // 18 words = 192 bits entropy


### PR DESCRIPTION
Breaking: Update MSRV to 1.80 (required by dependencies)

- Update Rust version in CI from 1.70.0 to 1.80.0
- Add rust-version = "1.80" to Cargo.toml files
- Fix all 40+ clippy warnings across workspace
- Fix benchmark seed lengths (68/67 bytes → 64 bytes max)
- Improve CI workflow with better caching and lockfile generation
- Update GitHub Actions to v4

All tests passing (707 total). Clippy clean. Ready for CI.