### PR TITLE
feat(bip44): Implement Chain enum for external/internal address chains

### DIFF
--- a/crates/bip44/src/lib.rs
+++ b/crates/bip44/src/lib.rs
@@ -23,7 +23,7 @@ mod error;
 mod types;
 
 pub use error::Error;
-pub use types::Purpose;
+pub use types::{Chain, Purpose};
 
 /// Result type alias for BIP-44 operations.
 pub type Result<T> = std::result::Result<T, Error>;

--- a/docs/implementations/bip44_tasks.md
+++ b/docs/implementations/bip44_tasks.md
@@ -12,7 +12,7 @@ Create error types: `InvalidPurpose`, `InvalidCoinType`, `InvalidChain`, `Invali
 ### ✅ Task 03: Define and test Purpose enum (BIP44, BIP49, BIP84, BIP86) with conversions (TDD)
 Implement `Purpose` enum with BIP44/49/84/86 variants, conversion traits (TryFrom<u32>, From for u32), and Display. Test valid/invalid conversions.
 
-### 🔲 Task 04: Define and test Chain enum (External=0, Internal=1) with conversions (TDD)
+### ✅ Task 04: Define and test Chain enum (External=0, Internal=1) with conversions (TDD)
 Implement `Chain` enum for receive (0) and change (1) addresses with conversions and helper methods. Test valid/invalid chain values.
 
 ## 💰 PHASE 2: Coin Type Registry (HIGH Priority)


### PR DESCRIPTION
- Define Chain enum with External (0) and Internal (1) variants
- Implement TryFrom<u32> for parsing with validation
- Implement From<Chain> for u32 conversion
- Add Display trait for formatting ("external"/"internal")
- Add helper methods: value(), name(), is_external(), is_internal()
- Include comprehensive documentation with examples
- Add 13 unit tests covering all conversions and helpers
- Add 9 doc tests for usage examples
- All tests passing (32 unit + 24 doc tests)