### PR TITLE
feat(bip44): Implement CoinType conversions and validation helpers

### DIFF
--- a/docs/implementations/bip44_tasks.md
+++ b/docs/implementations/bip44_tasks.md
@@ -20,7 +20,7 @@ Implement `Chain` enum for receive (0) and change (1) addresses with conversions
 ### ✅ Task 05: Define CoinType enum with SLIP-44 coin types and Custom(u32) variant
 Define `CoinType` enum with Bitcoin, Ethereum, Litecoin, etc., plus `Custom(u32)` for unlisted coins. Map to SLIP-44 indices.
 
-### 🔲 Task 06: Write tests and implement CoinType conversions and validation (TDD)
+### ✅ Task 06: Write tests and implement CoinType conversions and validation (TDD)
 Implement conversions (TryFrom<u32>, From for u32) and helpers (`is_testnet()`, `default_purpose()`). Test known/unknown coin types.
 
 ## 🛤️ PHASE 3: Path Construction (HIGH → MEDIUM Priority)


### PR DESCRIPTION
- Implement TryFrom<u32> for parsing SLIP-44 indices (never fails)
- Known coins map to specific variants, unknown become Custom
- Implement From<CoinType> for u32 conversion
- Add Display trait formatting coins as symbols (e.g., "BTC", "ETH")
- Add is_testnet() helper to detect testnet coins
- Add default_purpose() helper for default BIP standard per coin
  - Bitcoin/Litecoin default to BIP-84 (Native SegWit)
  - Others default to BIP-44
- Add 8 comprehensive unit tests covering all conversions
- Test round-trip conversions, display, validation helpers
- All tests passing (49 unit + 34 doc tests)