### PR TITLE
feat(bip44): Implement conversion to BIP32 DerivationPath

### DIFF
--- a/docs/implementations/bip44_tasks.md
+++ b/docs/implementations/bip44_tasks.md
@@ -31,7 +31,7 @@ Create `Bip44Path` struct with purpose, coin_type, account, chain, and address_i
 ### ✅ Task 08: Implement Bip44PathBuilder pattern with fluent API (TDD)
 Create builder for fluent path construction: `Bip44Path::builder().purpose(BIP44).coin_type(Bitcoin).account(0)...`. Test builder pattern.
 
-### 🔲 Task 09: Implement and test conversion to BIP32 DerivationPath (TDD)
+### ✅ Task 09: Implement and test conversion to BIP32 DerivationPath (TDD)
 Convert `Bip44Path` to BIP32 `DerivationPath` with proper hardened levels (m/purpose'/coin'/account'/chain/index). Test conversion.
 
 ### 🔲 Task 10: Implement and test FromStr and Display traits for path parsing/formatting (TDD)


### PR DESCRIPTION
- Add to_derivation_path() method to convert Bip44Path to DerivationPath
- Implement From<Bip44Path> for DerivationPath trait
- Implement From<&Bip44Path> for DerivationPath trait
- Follow BIP-44 derivation rules:
  - First 3 levels (purpose, coin_type, account) use hardened derivation
  - Last 2 levels (chain, address_index) use normal derivation
- Properly construct ChildNumber::Hardened and ChildNumber::Normal
- Add comprehensive documentation with conversion examples
- Add 13 unit tests covering:
  - Bitcoin, Ethereum, and custom coin conversions
  - Different accounts, chains, and address indices
  - All BIP purposes (44, 49, 84, 86)
  - Trait conversions by value and reference
  - Hardening rules validation
  - Display format verification
- Add 3 doc tests with usage examples
- All tests passing (87 unit + 54 doc tests)

Enables seamless integration with BIP-32 derivation system