### PR TITLE
feat(bip44): Implement FromStr and Display for path parsing

### DIFF
--- a/docs/implementations/bip44_tasks.md
+++ b/docs/implementations/bip44_tasks.md
@@ -34,7 +34,7 @@ Create builder for fluent path construction: `Bip44Path::builder().purpose(BIP44
 ### ✅ Task 09: Implement and test conversion to BIP32 DerivationPath (TDD)
 Convert `Bip44Path` to BIP32 `DerivationPath` with proper hardened levels (m/purpose'/coin'/account'/chain/index). Test conversion.
 
-### 🔲 Task 10: Implement and test FromStr and Display traits for path parsing/formatting (TDD)
+### ✅ Task 10: Implement and test FromStr and Display traits for path parsing/formatting (TDD)
 Parse "m/44'/0'/0'/0/0" strings to `Bip44Path` and format back. Test valid/invalid path strings.
 
 ## 🏗️ PHASE 4: Path Validation & Helpers (MEDIUM Priority)


### PR DESCRIPTION
- Add Display trait for "m/44'/0'/0'/0/0" formatting
- Add FromStr trait with strict BIP-44 validation
- Enforce hardening rules (first 3 hardened, last 2 normal)
- Validate path structure (must start with "m/", exactly 5 levels)
- Provide detailed parse error messages
- Add 33 unit tests + 2 doc tests (all passing)
- Enable seamless string ⟷ Bip44Path conversion