### PR TITLE
feat(bip44): Implement path validation and DerivationPath conversion

### DIFF
--- a/docs/implementations/bip44_tasks.md
+++ b/docs/implementations/bip44_tasks.md
@@ -39,7 +39,7 @@ Parse "m/44'/0'/0'/0/0" strings to `Bip44Path` and format back. Test valid/inval
 
 ## 🏗️ PHASE 4: Path Validation & Helpers (MEDIUM Priority)
 
-### 🔲 Task 11: Implement and test path validation (depth, hardened levels, ranges) (TDD)
+### ✅ Task 11: Implement and test path validation (depth, hardened levels, ranges) (TDD)
 Validate path depth (must be 5), first 3 levels hardened, and index ranges. Test invalid paths are rejected.
 
 ### 🔲 Task 12: Implement and test path manipulation helpers (increment, next address) (TDD)


### PR DESCRIPTION
- Add is_valid() and depth() validation methods
- Implement TryFrom<DerivationPath> with strict BIP-44 validation
- Enforce depth, hardening, and value range rules
- Validate: 5 levels, first 3 hardened, last 2 normal
- Return detailed errors for each validation failure
- Add 21 unit tests + 4 doc tests (all passing)
- Enable bidirectional Bip44Path ⟷ DerivationPath conversion