### PR TITLE
feat(bip44): Implement path manipulation helpers

### DIFF
--- a/docs/implementations/bip44_tasks.md
+++ b/docs/implementations/bip44_tasks.md
@@ -42,7 +42,7 @@ Parse "m/44'/0'/0'/0/0" strings to `Bip44Path` and format back. Test valid/inval
 ### ✅ Task 11: Implement and test path validation (depth, hardened levels, ranges) (TDD)
 Validate path depth (must be 5), first 3 levels hardened, and index ranges. Test invalid paths are rejected.
 
-### 🔲 Task 12: Implement and test path manipulation helpers (increment, next address) (TDD)
+### ✅ Task 12: Implement and test path manipulation helpers (increment, next address) (TDD)
 Add methods to increment address index, get next chain address, and navigate paths. Test helper utilities.
 
 ## 🎯 PHASE 5: Account Management (MEDIUM Priority)


### PR DESCRIPTION
- Add next_address() to increment address index (with wrapping)
- Add with_address_index() to set specific address index
- Add chain navigation: with_chain(), to_external(), to_internal()
- Add account navigation: with_account(), next_account() (validated)
- Add with_purpose() and with_coin_type() for path modification
- All methods return new instances (immutable pattern)
- Support method chaining for complex transformations
- Validate account values against MAX_HARDENED_INDEX
- Add 22 unit tests + 9 doc tests (all passing)
- Test address sequences, chain switching, account overflow, chaining