### PR TITLE
feat(bip44): Implement external and internal chain derivation

### DIFF
--- a/docs/implementations/bip44_tasks.md
+++ b/docs/implementations/bip44_tasks.md
@@ -50,7 +50,7 @@ Add methods to increment address index, get next chain address, and navigate pat
 ### ✅ Task 13: Define Account struct and implement constructor from BIP32 keys (TDD)
 Wrap `ExtendedPrivateKey` with BIP44 metadata (purpose, coin, account). Create from BIP32 keys. Test construction.
 
-### 🔲 Task 14: Implement and test derive_external() and derive_internal() methods (TDD)
+### ✅ Task 14: Implement and test derive_external() and derive_internal() methods (TDD)
 Derive receiving (external) and change (internal) addresses from account key. Test both chain derivations.
 
 ### 🔲 Task 15: Implement and test derive_address() and derive_address_range() methods (TDD)


### PR DESCRIPTION
- Add derive_external() for receiving address derivation (chain 0)
- Add derive_internal() for change address derivation (chain 1)
- Derive to full BIP-44 path: m/purpose'/coin_type'/account'/chain/address_index
- Use normal (non-hardened) derivation for chain and address levels
- Support full range of address indices (0 to u32::MAX)
- Preserve network across derivations (mainnet/testnet)
- Ensure deterministic key generation
- Add 14 unit tests + 2 doc tests (all passing)
- Test sequential derivation, chain separation, large indices, network preservation