### PR TITLE
feat(bip44): Implement batch address derivation methods

### DIFF
--- a/docs/implementations/bip44_tasks.md
+++ b/docs/implementations/bip44_tasks.md
@@ -53,7 +53,7 @@ Wrap `ExtendedPrivateKey` with BIP44 metadata (purpose, coin, account). Create f
 ### ✅ Task 14: Implement and test derive_external() and derive_internal() methods (TDD)
 Derive receiving (external) and change (internal) addresses from account key. Test both chain derivations.
 
-### 🔲 Task 15: Implement and test derive_address() and derive_address_range() methods (TDD)
+### ✅ Task 15: Implement and test derive_address() and derive_address_range() methods (TDD)
 Derive single address by index and batch derive address ranges. Test sequential address generation.
 
 ## 🔍 PHASE 6: Account Discovery Algorithm (MEDIUM Priority)


### PR DESCRIPTION
- Add derive_address() for unified chain-based derivation
- Add derive_address_range() for batch address generation
- Support both external and internal chain derivation
- Enable efficient batch generation with vector pre-allocation
- Use saturating arithmetic for overflow protection
- Support gap limit scanning (BIP-44 typical 20 addresses)
- Allow sequential batch generation with start offset
- Add 13 unit tests + 2 doc tests (all passing)
- Test empty ranges, single addresses, large counts, batch continuity