### PR TITLE
feat(bip44): Implement AccountDiscovery trait and gap limit algorithm

### DIFF
--- a/crates/bip44/src/discovery.rs
+++ b/crates/bip44/src/discovery.rs
@@ -1,0 +1,574 @@
+//! BIP-44 account discovery and gap limit implementation.
+//!
+//! This module provides traits and utilities for discovering used addresses and accounts
+//! according to BIP-44 specifications. The gap limit algorithm stops searching after
+//! finding a configurable number of consecutive unused addresses (typically 20).
+//!
+//! # Gap Limit
+//!
+//! BIP-44 defines a "gap limit" to determine when to stop scanning for addresses:
+//! - If 20 consecutive unused addresses are found, stop scanning that chain
+//! - This prevents infinite scanning while allowing address gaps
+//! - Both external and internal chains have separate gap limits
+//!
+//! # Examples
+//!
+//! ```rust
+//! use khodpay_bip44::{AccountDiscovery, GapLimitChecker};
+//! use std::collections::HashSet;
+//!
+//! // Mock blockchain query - addresses 0, 2, 5 are used
+//! struct MockBlockchain {
+//!     used_addresses: HashSet<u32>,
+//! }
+//!
+//! impl AccountDiscovery for MockBlockchain {
+//!     fn is_address_used(&self, address_index: u32) -> std::result::Result<bool, Box<dyn std::error::Error>> {
+//!         Ok(self.used_addresses.contains(&address_index))
+//!     }
+//! }
+//!
+//! let mut blockchain = MockBlockchain {
+//!     used_addresses: [0, 2, 5].iter().copied().collect(),
+//! };
+//!
+//! let checker = GapLimitChecker::new(20);
+//! let last_used = checker.find_last_used_index(&blockchain, 0).unwrap();
+//! assert_eq!(last_used, Some(5));
+//! ```
+
+/// Default gap limit as specified by BIP-44.
+///
+/// BIP-44 recommends stopping the scan after finding 20 consecutive unused addresses.
+pub const DEFAULT_GAP_LIMIT: u32 = 20;
+
+/// Trait for querying blockchain state to discover address usage.
+///
+/// Implementations of this trait provide the ability to check whether
+/// a specific address has been used on the blockchain (has transaction history).
+///
+/// # Examples
+///
+/// ```rust
+/// use khodpay_bip44::AccountDiscovery;
+/// use std::collections::HashSet;
+///
+/// struct SimpleBlockchain {
+///     used_indices: HashSet<u32>,
+/// }
+///
+/// impl AccountDiscovery for SimpleBlockchain {
+///     fn is_address_used(&self, address_index: u32) -> std::result::Result<bool, Box<dyn std::error::Error>> {
+///         Ok(self.used_indices.contains(&address_index))
+///     }
+/// }
+/// ```
+pub trait AccountDiscovery {
+    /// Checks if an address at the given index has been used.
+    ///
+    /// An address is considered "used" if it has any transaction history
+    /// on the blockchain (either received or sent funds).
+    ///
+    /// # Arguments
+    ///
+    /// * `address_index` - The address index to check
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the blockchain query fails.
+    fn is_address_used(&self, address_index: u32) -> std::result::Result<bool, Box<dyn std::error::Error>>;
+}
+
+/// Gap limit checker for BIP-44 address discovery.
+///
+/// Implements the gap limit algorithm to find the last used address index
+/// on a chain. The algorithm stops scanning after finding a configurable
+/// number of consecutive unused addresses.
+///
+/// # Examples
+///
+/// ```rust
+/// use khodpay_bip44::{AccountDiscovery, GapLimitChecker};
+/// use std::collections::HashSet;
+///
+/// struct MockBlockchain {
+///     used: HashSet<u32>,
+/// }
+///
+/// impl AccountDiscovery for MockBlockchain {
+///     fn is_address_used(&self, address_index: u32) -> std::result::Result<bool, Box<dyn std::error::Error>> {
+///         Ok(self.used.contains(&address_index))
+///     }
+/// }
+///
+/// let blockchain = MockBlockchain {
+///     used: [0, 1, 5, 10].iter().copied().collect(),
+/// };
+///
+/// let checker = GapLimitChecker::new(20);
+/// let result = checker.find_last_used_index(&blockchain, 0).unwrap();
+/// assert_eq!(result, Some(10));
+/// ```
+#[derive(Debug, Clone, Copy)]
+pub struct GapLimitChecker {
+    /// The number of consecutive unused addresses to find before stopping
+    gap_limit: u32,
+}
+
+impl GapLimitChecker {
+    /// Creates a new gap limit checker with the specified limit.
+    ///
+    /// # Arguments
+    ///
+    /// * `gap_limit` - Number of consecutive unused addresses before stopping
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use khodpay_bip44::GapLimitChecker;
+    ///
+    /// let checker = GapLimitChecker::new(20);
+    /// assert_eq!(checker.gap_limit(), 20);
+    /// ```
+    pub fn new(gap_limit: u32) -> Self {
+        Self { gap_limit }
+    }
+
+    /// Creates a new gap limit checker with the default BIP-44 limit (20).
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use khodpay_bip44::{GapLimitChecker, DEFAULT_GAP_LIMIT};
+    ///
+    /// let checker = GapLimitChecker::default();
+    /// assert_eq!(checker.gap_limit(), DEFAULT_GAP_LIMIT);
+    /// ```
+    pub fn default() -> Self {
+        Self::new(DEFAULT_GAP_LIMIT)
+    }
+
+    /// Returns the configured gap limit.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use khodpay_bip44::GapLimitChecker;
+    ///
+    /// let checker = GapLimitChecker::new(10);
+    /// assert_eq!(checker.gap_limit(), 10);
+    /// ```
+    pub const fn gap_limit(&self) -> u32 {
+        self.gap_limit
+    }
+
+    /// Finds the last used address index on a chain using the gap limit algorithm.
+    ///
+    /// Scans addresses starting from `start_index` and stops after finding
+    /// `gap_limit` consecutive unused addresses. Returns the highest used
+    /// address index found, or `None` if no addresses are used.
+    ///
+    /// # Arguments
+    ///
+    /// * `discovery` - Implementation of blockchain query interface
+    /// * `start_index` - The address index to start scanning from
+    ///
+    /// # Returns
+    ///
+    /// - `Some(index)` - The highest used address index found
+    /// - `None` - No used addresses found
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if any blockchain query fails.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use khodpay_bip44::{AccountDiscovery, GapLimitChecker};
+    /// use std::collections::HashSet;
+    ///
+    /// struct TestBlockchain {
+    ///     used: HashSet<u32>,
+    /// }
+    ///
+    /// impl AccountDiscovery for TestBlockchain {
+    ///     fn is_address_used(&self, index: u32) -> std::result::Result<bool, Box<dyn std::error::Error>> {
+    ///         Ok(self.used.contains(&index))
+    ///     }
+    /// }
+    ///
+    /// let blockchain = TestBlockchain {
+    ///     used: [0, 5, 10].iter().copied().collect(),
+    /// };
+    ///
+    /// let checker = GapLimitChecker::new(20);
+    /// let last = checker.find_last_used_index(&blockchain, 0).unwrap();
+    /// assert_eq!(last, Some(10));
+    /// ```
+    pub fn find_last_used_index<D: AccountDiscovery>(
+        &self,
+        discovery: &D,
+        start_index: u32,
+    ) -> std::result::Result<Option<u32>, Box<dyn std::error::Error>> {
+        let mut last_used_index: Option<u32> = None;
+        let mut consecutive_unused = 0u32;
+        let mut current_index = start_index;
+
+        loop {
+            // Check if address is used
+            let is_used = discovery.is_address_used(current_index)?;
+
+            if is_used {
+                // Found a used address, reset gap counter and update last used
+                last_used_index = Some(current_index);
+                consecutive_unused = 0;
+            } else {
+                // Found an unused address, increment gap counter
+                consecutive_unused += 1;
+
+                // Stop if we've found enough consecutive unused addresses
+                if consecutive_unused >= self.gap_limit {
+                    break;
+                }
+            }
+
+            // Move to next address, stop if we'd overflow
+            if let Some(next) = current_index.checked_add(1) {
+                current_index = next;
+            } else {
+                // Reached u32::MAX
+                break;
+            }
+        }
+
+        Ok(last_used_index)
+    }
+
+    /// Finds all used address indices on a chain up to the gap limit.
+    ///
+    /// Returns a vector of all used address indices found during scanning.
+    ///
+    /// # Arguments
+    ///
+    /// * `discovery` - Implementation of blockchain query interface
+    /// * `start_index` - The address index to start scanning from
+    ///
+    /// # Returns
+    ///
+    /// A vector of used address indices in ascending order.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if any blockchain query fails.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use khodpay_bip44::{AccountDiscovery, GapLimitChecker};
+    /// use std::collections::HashSet;
+    ///
+    /// struct TestBlockchain {
+    ///     used: HashSet<u32>,
+    /// }
+    ///
+    /// impl AccountDiscovery for TestBlockchain {
+    ///     fn is_address_used(&self, index: u32) -> std::result::Result<bool, Box<dyn std::error::Error>> {
+    ///         Ok(self.used.contains(&index))
+    ///     }
+    /// }
+    ///
+    /// let blockchain = TestBlockchain {
+    ///     used: [0, 2, 5].iter().copied().collect(),
+    /// };
+    ///
+    /// let checker = GapLimitChecker::new(20);
+    /// let used = checker.find_used_indices(&blockchain, 0).unwrap();
+    /// assert_eq!(used, vec![0, 2, 5]);
+    /// ```
+    pub fn find_used_indices<D: AccountDiscovery>(
+        &self,
+        discovery: &D,
+        start_index: u32,
+    ) -> std::result::Result<Vec<u32>, Box<dyn std::error::Error>> {
+        let mut used_indices = Vec::new();
+        let mut consecutive_unused = 0u32;
+        let mut current_index = start_index;
+
+        loop {
+            // Check if address is used
+            let is_used = discovery.is_address_used(current_index)?;
+
+            if is_used {
+                used_indices.push(current_index);
+                consecutive_unused = 0;
+            } else {
+                consecutive_unused += 1;
+
+                if consecutive_unused >= self.gap_limit {
+                    break;
+                }
+            }
+
+            // Move to next address
+            if let Some(next) = current_index.checked_add(1) {
+                current_index = next;
+            } else {
+                break;
+            }
+        }
+
+        Ok(used_indices)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    // Mock blockchain implementation for testing
+    struct MockBlockchain {
+        used_addresses: HashSet<u32>,
+    }
+
+    impl AccountDiscovery for MockBlockchain {
+        fn is_address_used(&self, address_index: u32) -> std::result::Result<bool, Box<dyn std::error::Error>> {
+            Ok(self.used_addresses.contains(&address_index))
+        }
+    }
+
+    #[test]
+    fn test_gap_limit_checker_new() {
+        let checker = GapLimitChecker::new(10);
+        assert_eq!(checker.gap_limit(), 10);
+
+        let checker = GapLimitChecker::new(20);
+        assert_eq!(checker.gap_limit(), 20);
+    }
+
+    #[test]
+    fn test_gap_limit_checker_default() {
+        let checker = GapLimitChecker::default();
+        assert_eq!(checker.gap_limit(), DEFAULT_GAP_LIMIT);
+        assert_eq!(checker.gap_limit(), 20);
+    }
+
+    #[test]
+    fn test_find_last_used_no_addresses() {
+        let blockchain = MockBlockchain {
+            used_addresses: HashSet::new(),
+        };
+
+        let checker = GapLimitChecker::new(20);
+        let result = checker.find_last_used_index(&blockchain, 0).unwrap();
+        
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_find_last_used_single_address() {
+        let blockchain = MockBlockchain {
+            used_addresses: [5].iter().copied().collect(),
+        };
+
+        let checker = GapLimitChecker::new(20);
+        let result = checker.find_last_used_index(&blockchain, 0).unwrap();
+        
+        assert_eq!(result, Some(5));
+    }
+
+    #[test]
+    fn test_find_last_used_multiple_addresses() {
+        let blockchain = MockBlockchain {
+            used_addresses: [0, 2, 5, 10].iter().copied().collect(),
+        };
+
+        let checker = GapLimitChecker::new(20);
+        let result = checker.find_last_used_index(&blockchain, 0).unwrap();
+        
+        assert_eq!(result, Some(10));
+    }
+
+    #[test]
+    fn test_find_last_used_with_gap() {
+        let blockchain = MockBlockchain {
+            used_addresses: [0, 1, 2, 25].iter().copied().collect(),
+        };
+
+        let checker = GapLimitChecker::new(20);
+        let result = checker.find_last_used_index(&blockchain, 0).unwrap();
+        
+        // Should stop at index 2 because there's a gap of 20+ after it
+        assert_eq!(result, Some(2));
+    }
+
+    #[test]
+    fn test_find_last_used_gap_limit_5() {
+        let blockchain = MockBlockchain {
+            used_addresses: [0, 1, 2, 10].iter().copied().collect(),
+        };
+
+        let checker = GapLimitChecker::new(5);
+        let result = checker.find_last_used_index(&blockchain, 0).unwrap();
+        
+        // With gap limit 5, should stop at index 2
+        assert_eq!(result, Some(2));
+    }
+
+    #[test]
+    fn test_find_last_used_consecutive_addresses() {
+        let blockchain = MockBlockchain {
+            used_addresses: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9].iter().copied().collect(),
+        };
+
+        let checker = GapLimitChecker::new(20);
+        let result = checker.find_last_used_index(&blockchain, 0).unwrap();
+        
+        assert_eq!(result, Some(9));
+    }
+
+    #[test]
+    fn test_find_last_used_sparse_addresses() {
+        let blockchain = MockBlockchain {
+            used_addresses: [0, 5, 10, 15, 19].iter().copied().collect(),
+        };
+
+        let checker = GapLimitChecker::new(20);
+        let result = checker.find_last_used_index(&blockchain, 0).unwrap();
+        
+        assert_eq!(result, Some(19));
+    }
+
+    #[test]
+    fn test_find_last_used_start_offset() {
+        let blockchain = MockBlockchain {
+            used_addresses: [10, 15, 20].iter().copied().collect(),
+        };
+
+        let checker = GapLimitChecker::new(20);
+        let result = checker.find_last_used_index(&blockchain, 10).unwrap();
+        
+        assert_eq!(result, Some(20));
+    }
+
+    #[test]
+    fn test_find_last_used_exact_gap_limit() {
+        let blockchain = MockBlockchain {
+            used_addresses: [0, 20].iter().copied().collect(),
+        };
+
+        let checker = GapLimitChecker::new(20);
+        let result = checker.find_last_used_index(&blockchain, 0).unwrap();
+        
+        // Gap is exactly 20, should find address 20
+        assert_eq!(result, Some(20));
+    }
+
+    #[test]
+    fn test_find_used_indices_empty() {
+        let blockchain = MockBlockchain {
+            used_addresses: HashSet::new(),
+        };
+
+        let checker = GapLimitChecker::new(20);
+        let result = checker.find_used_indices(&blockchain, 0).unwrap();
+        
+        assert_eq!(result, Vec::<u32>::new());
+    }
+
+    #[test]
+    fn test_find_used_indices_single() {
+        let blockchain = MockBlockchain {
+            used_addresses: [5].iter().copied().collect(),
+        };
+
+        let checker = GapLimitChecker::new(20);
+        let result = checker.find_used_indices(&blockchain, 0).unwrap();
+        
+        assert_eq!(result, vec![5]);
+    }
+
+    #[test]
+    fn test_find_used_indices_multiple() {
+        let blockchain = MockBlockchain {
+            used_addresses: [0, 2, 5, 10].iter().copied().collect(),
+        };
+
+        let checker = GapLimitChecker::new(20);
+        let result = checker.find_used_indices(&blockchain, 0).unwrap();
+        
+        assert_eq!(result, vec![0, 2, 5, 10]);
+    }
+
+    #[test]
+    fn test_find_used_indices_with_gap() {
+        let blockchain = MockBlockchain {
+            used_addresses: [0, 1, 2, 30].iter().copied().collect(),
+        };
+
+        let checker = GapLimitChecker::new(20);
+        let result = checker.find_used_indices(&blockchain, 0).unwrap();
+        
+        // Should stop before reaching 30 due to gap limit
+        assert_eq!(result, vec![0, 1, 2]);
+    }
+
+    #[test]
+    fn test_find_used_indices_ordered() {
+        let blockchain = MockBlockchain {
+            used_addresses: [10, 5, 15, 0].iter().copied().collect(),
+        };
+
+        let checker = GapLimitChecker::new(20);
+        let result = checker.find_used_indices(&blockchain, 0).unwrap();
+        
+        // Should return in ascending order
+        assert_eq!(result, vec![0, 5, 10, 15]);
+    }
+
+    #[test]
+    fn test_clone_and_copy() {
+        let checker1 = GapLimitChecker::new(15);
+        let checker2 = checker1;
+        let checker3 = checker1.clone();
+        
+        assert_eq!(checker1.gap_limit(), 15);
+        assert_eq!(checker2.gap_limit(), 15);
+        assert_eq!(checker3.gap_limit(), 15);
+    }
+
+    #[test]
+    fn test_debug_format() {
+        let checker = GapLimitChecker::new(20);
+        let debug_str = format!("{:?}", checker);
+        
+        assert!(debug_str.contains("GapLimitChecker"));
+        assert!(debug_str.contains("20"));
+    }
+
+    #[test]
+    fn test_gap_limit_1() {
+        let blockchain = MockBlockchain {
+            used_addresses: [0, 2].iter().copied().collect(),
+        };
+
+        let checker = GapLimitChecker::new(1);
+        let result = checker.find_last_used_index(&blockchain, 0).unwrap();
+        
+        // Should stop immediately after first unused address
+        assert_eq!(result, Some(0));
+    }
+
+    #[test]
+    fn test_large_gap_limit() {
+        let blockchain = MockBlockchain {
+            used_addresses: [0, 10, 20].iter().copied().collect(),
+        };
+
+        let checker = GapLimitChecker::new(100);
+        let result = checker.find_last_used_index(&blockchain, 0).unwrap();
+        
+        assert_eq!(result, Some(20));
+    }
+}

--- a/crates/bip44/src/lib.rs
+++ b/crates/bip44/src/lib.rs
@@ -20,11 +20,13 @@
 #![deny(unsafe_code)]
 
 mod account;
+mod discovery;
 mod error;
 mod path;
 mod types;
 
 pub use account::Account;
+pub use discovery::{AccountDiscovery, GapLimitChecker, DEFAULT_GAP_LIMIT};
 pub use error::Error;
 pub use path::{Bip44Path, Bip44PathBuilder};
 pub use types::{Chain, CoinType, Purpose};

--- a/docs/implementations/bip44_tasks.md
+++ b/docs/implementations/bip44_tasks.md
@@ -58,7 +58,7 @@ Derive single address by index and batch derive address ranges. Test sequential 
 
 ## 🔍 PHASE 6: Account Discovery Algorithm (MEDIUM Priority)
 
-### 🔲 Task 16: Define AccountDiscovery trait and implement gap limit logic (TDD)
+### ✅ Task 16: Define AccountDiscovery trait and implement gap limit logic (TDD)
 Create trait for blockchain queries. Implement gap limit (stop after 20 consecutive unused addresses). Test gap detection.
 
 ### 🔲 Task 17: Implement AccountScanner with discover_accounts() and scan_chain() methods (TDD)


### PR DESCRIPTION
- Add AccountDiscovery trait for blockchain address usage queries
- Implement GapLimitChecker with BIP-44 gap limit algorithm
- Add find_last_used_index() to find highest used address
- Add find_used_indices() to get all used addresses in range
- Stop scanning after N consecutive unused addresses (default 20)
- Support custom gap limits for different use cases
- Include DEFAULT_GAP_LIMIT constant (20 per BIP-44)
- Implement Debug, Clone, Copy traits for GapLimitChecker
- Add overflow protection with checked arithmetic
- Add 20 unit tests covering all edge cases
- Test empty chains, gaps, boundaries, custom limits, sparse addresses