### PR TITLE
feat(bip44): Implement AccountScanner for account discovery

### DIFF
--- a/crates/bip44/src/lib.rs
+++ b/crates/bip44/src/lib.rs
@@ -26,7 +26,10 @@ mod path;
 mod types;
 
 pub use account::Account;
-pub use discovery::{AccountDiscovery, GapLimitChecker, DEFAULT_GAP_LIMIT};
+pub use discovery::{
+    AccountDiscovery, AccountScanResult, AccountScanner, ChainScanResult, GapLimitChecker,
+    DEFAULT_GAP_LIMIT,
+};
 pub use error::Error;
 pub use path::{Bip44Path, Bip44PathBuilder};
 pub use types::{Chain, CoinType, Purpose};

--- a/docs/implementations/bip44_tasks.md
+++ b/docs/implementations/bip44_tasks.md
@@ -61,7 +61,7 @@ Derive single address by index and batch derive address ranges. Test sequential 
 ### ✅ Task 16: Define AccountDiscovery trait and implement gap limit logic (TDD)
 Create trait for blockchain queries. Implement gap limit (stop after 20 consecutive unused addresses). Test gap detection.
 
-### 🔲 Task 17: Implement AccountScanner with discover_accounts() and scan_chain() methods (TDD)
+### ✅ Task 17: Implement AccountScanner with discover_accounts() and scan_chain() methods (TDD)
 Scan accounts and chains using discovery trait. Find all used accounts/addresses. Test discovery algorithm.
 
 ### 🔲 Task 18: Create mock blockchain backend for testing (TDD)


### PR DESCRIPTION
- Add ChainScanResult struct to hold single chain scan results
- Add AccountScanResult struct with external/internal chain results
- Implement AccountScanner for discovering used accounts and addresses
- Add scan_chain() to scan single chain for used addresses
- Add discover_accounts() to find all used accounts up to max limit
- Stop scanning at first unused account (BIP-44 account gap rule)
- Include is_used() and total_used_count() helper methods
- Implement Debug, Clone, PartialEq, Eq traits for result types
- Add 16 unit tests + 6 doc tests (all passing)
- Test empty chains, single/multiple accounts, max limits, equality