### PR TITLE
feat(bip44): Add MockBlockchain for testing discovery

### DIFF
--- a/crates/bip44/src/lib.rs
+++ b/crates/bip44/src/lib.rs
@@ -28,7 +28,7 @@ mod types;
 pub use account::Account;
 pub use discovery::{
     AccountDiscovery, AccountScanResult, AccountScanner, ChainScanResult, GapLimitChecker,
-    DEFAULT_GAP_LIMIT,
+    MockBlockchain, DEFAULT_GAP_LIMIT,
 };
 pub use error::Error;
 pub use path::{Bip44Path, Bip44PathBuilder};

--- a/docs/implementations/bip44_tasks.md
+++ b/docs/implementations/bip44_tasks.md
@@ -64,7 +64,7 @@ Create trait for blockchain queries. Implement gap limit (stop after 20 consecut
 ### ✅ Task 17: Implement AccountScanner with discover_accounts() and scan_chain() methods (TDD)
 Scan accounts and chains using discovery trait. Find all used accounts/addresses. Test discovery algorithm.
 
-### 🔲 Task 18: Create mock blockchain backend for testing (TDD)
+### ✅ Task 18: Create mock blockchain backend for testing (TDD)
 Mock blockchain with configurable used addresses for testing account discovery without real blockchain.
 
 ## 🏦 PHASE 7: Wallet Abstraction (LOW → MEDIUM Priority)


### PR DESCRIPTION
- Implement MockBlockchain struct for in-memory blockchain testing
- Add new() and with_used_addresses() constructors
- Add mark_used(), mark_used_batch(), mark_unused() for state management
- Add used_count(), get_used_addresses(), clear(), is_empty() query methods
- Implement AccountDiscovery trait for seamless integration
- Support mutable operations for dynamic test scenarios
- Return sorted addresses for predictable testing
- Support large address indices (tested up to 100,000)
- Implement Debug, Clone, Default traits
- Add 19 unit tests + 10 doc tests (all passing)
- Test construction, mutation, trait integration, edge cases