### PR TITLE
fix(bip39): use OsRng for mobile/static library compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2024-12-01
+
+### Changed
+
+#### BIP39
+- 🔄 **Switched to `OsRng` for entropy generation** - Replaced `rand::thread_rng()` with `rand::rngs::OsRng` for reliable random number generation on mobile devices and static library builds
+
+### Fixed
+- 🐛 Fixed potential issues with thread-local RNG on iOS/Android static library targets
+
 ## [0.3.0] - 2024-11-02
 
 ### Added
@@ -112,7 +122,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ⚡ Minimal allocations
 - ⚡ Zero-copy operations where possible
 
-[Unreleased]: https://github.com/khodpay/rust-wallet/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/khodpay/rust-wallet/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/khodpay/rust-wallet/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/khodpay/rust-wallet/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/khodpay/rust-wallet/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/khodpay/rust-wallet/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -376,7 +376,7 @@ dependencies = [
 
 [[package]]
 name = "khodpay-bip39"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bip39",
  "criterion",

--- a/crates/bip39/Cargo.toml
+++ b/crates/bip39/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "khodpay-bip39"
-version = "0.2.0"
+version = "0.4.0"
 edition = "2021"
 rust-version = "1.81"
 authors = ["KhodPay Team"]

--- a/crates/bip39/src/mnemonic.rs
+++ b/crates/bip39/src/mnemonic.rs
@@ -352,7 +352,7 @@ impl Mnemonic {
     /// # Security Note
     ///
     /// This function uses the system's cryptographically secure random number generator
-    /// (`rand::thread_rng()`). The generated mnemonic should be stored securely and
+    /// (`rand::rngs::OsRng`). The generated mnemonic should be stored securely and
     /// backed up properly. Loss of the mnemonic means permanent loss of wallet access.
     ///
     /// # Examples
@@ -370,15 +370,15 @@ impl Mnemonic {
     /// ```
     pub fn generate(word_count: WordCount, language: Language) -> crate::Result<Self> {
         use rand::RngCore;
+        use rand::rngs::OsRng;
 
         // Step 1: Calculate the required entropy length
         let entropy_length = word_count.entropy_length();
 
         // Step 2: Generate cryptographically secure random entropy
-        // Uses the system's secure random number generator
+        // Uses OsRng for reliable entropy on mobile/static library targets
         let mut entropy = vec![0u8; entropy_length];
-        let mut rng = rand::thread_rng();
-        rng.fill_bytes(&mut entropy);
+        OsRng.fill_bytes(&mut entropy);
 
         // Step 3: Use the `new()` constructor to create the Mnemonic
         // This handles entropy validation, checksum calculation, and phrase generation

--- a/crates/bip39/src/utils.rs
+++ b/crates/bip39/src/utils.rs
@@ -352,15 +352,15 @@ pub fn generate_mnemonic(word_count: WordCount) -> Result<String> {
 /// ```
 pub fn generate_mnemonic_in_language(word_count: WordCount, language: Language) -> Result<String> {
     use rand::RngCore;
+    use rand::rngs::OsRng;
 
     // Step 1: Calculate the required entropy length based on word count
     let entropy_length = word_count.entropy_length();
 
     // Step 2: Generate cryptographically secure random entropy
-    // Uses the system's secure random number generator
+    // Uses OsRng for reliable entropy on mobile/static library targets
     let mut entropy = vec![0u8; entropy_length];
-    let mut rng = rand::thread_rng();
-    rng.fill_bytes(&mut entropy);
+    OsRng.fill_bytes(&mut entropy);
 
     // Step 3: Convert language to upstream format
     let upstream_language = language.to_upstream();


### PR DESCRIPTION
Replace `rand::thread_rng()` with `rand::rngs::OsRng` for entropy generation in mnemonic creation functions.

`thread_rng()` relies on thread-local storage which may not work reliably on iOS/Android static library targets. `OsRng` directly uses the OS-provided CSPRNG (SecRandomCopyBytes on iOS/macOS, getrandom on Linux/Android) which is more portable.

Affected functions:
- Mnemonic::generate()
- generate_mnemonic_in_language()

Bumps khodpay-bip39 to v0.4.0