### PR TITLE
fix(bip39): use OsRng for mobile/static library compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -376,7 +376,7 @@ dependencies = [
 
 [[package]]
 name = "khodpay-bip39"
-version = "0.2.1"
+version = "0.4.0"
 dependencies = [
  "bip39",
  "criterion",

--- a/crates/bip32/Cargo.toml
+++ b/crates/bip32/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["bitcoin", "cryptocurrency", "bip32", "hd-wallet", "wallet"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-khodpay-bip39 = { version = "0.2.0", path = "../bip39" }
+khodpay-bip39 = { version = "0.4.0", path = "../bip39" }
 hmac = "0.12"
 sha2 = "0.10"
 ripemd = "0.1"

--- a/crates/bip44/Cargo.toml
+++ b/crates/bip44/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 khodpay-bip32 = { version = "0.2.0", path = "../bip32" }
-khodpay-bip39 = { version = "0.2.0", path = "../bip39" }
+khodpay-bip39 = { version = "0.4.0", path = "../bip39" }
 thiserror = "1.0"
 
 [dependencies.serde]


### PR DESCRIPTION
Replace `rand::thread_rng()` with `rand::rngs::OsRng` for entropy generation in mnemonic creation functions.

`thread_rng()` relies on thread-local storage which may not work reliably on iOS/Android static library targets. `OsRng` directly uses the OS-provided CSPRNG (SecRandomCopyBytes on iOS/macOS, getrandom on Linux/Android) which is more portable.

Affected functions:
- Mnemonic::generate()
- generate_mnemonic_in_language()

Bumps khodpay-bip39 to v0.4.0