### PR TITLE
fix(bip39): use OsRng for mobile/static library compatibility

### DIFF
--- a/crates/bip39/src/mnemonic.rs
+++ b/crates/bip39/src/mnemonic.rs
@@ -369,8 +369,8 @@ impl Mnemonic {
     /// assert_eq!(mnemonic_24.word_count(), WordCount::TwentyFour);
     /// ```
     pub fn generate(word_count: WordCount, language: Language) -> crate::Result<Self> {
-        use rand::RngCore;
         use rand::rngs::OsRng;
+        use rand::RngCore;
 
         // Step 1: Calculate the required entropy length
         let entropy_length = word_count.entropy_length();

--- a/crates/bip39/src/utils.rs
+++ b/crates/bip39/src/utils.rs
@@ -351,8 +351,8 @@ pub fn generate_mnemonic(word_count: WordCount) -> Result<String> {
 /// assert_eq!(mnemonic_ja.split_whitespace().count(), 24);
 /// ```
 pub fn generate_mnemonic_in_language(word_count: WordCount, language: Language) -> Result<String> {
-    use rand::RngCore;
     use rand::rngs::OsRng;
+    use rand::RngCore;
 
     // Step 1: Calculate the required entropy length based on word count
     let entropy_length = word_count.entropy_length();


### PR DESCRIPTION
Replace `rand::thread_rng()` with `rand::rngs::OsRng` for entropy generation in mnemonic creation functions.

`thread_rng()` relies on thread-local storage which may not work reliably on iOS/Android static library targets. `OsRng` directly uses the OS-provided CSPRNG (SecRandomCopyBytes on iOS/macOS, getrandom on Linux/Android) which is more portable.

Affected functions:
- Mnemonic::generate()
- generate_mnemonic_in_language()

Bumps khodpay-bip39 to v0.4.0