### PR TITLE
feat(signing): add Address and Wei types

### DIFF
--- a/crates/khodpay-signing/Cargo.toml
+++ b/crates/khodpay-signing/Cargo.toml
@@ -27,6 +27,9 @@ sha3 = "0.10"
 # U256 for Wei
 primitive-types = { version = "0.12", features = ["rlp"] }
 
+# Hex encoding
+hex = "0.4"
+
 # Security
 zeroize = { version = "1.7", features = ["derive"] }
 
@@ -38,4 +41,3 @@ default = []
 serde = ["dep:serde"]
 
 [dev-dependencies]
-hex = "0.4"

--- a/crates/khodpay-signing/src/address.rs
+++ b/crates/khodpay-signing/src/address.rs
@@ -1,0 +1,553 @@
+//! EVM address type with hex parsing and EIP-55 checksum support.
+//!
+//! An EVM address is a 20-byte identifier derived from the last 20 bytes of
+//! the Keccak-256 hash of the public key.
+
+use crate::{Error, Result};
+use sha3::{Digest, Keccak256};
+use std::fmt;
+use std::str::FromStr;
+
+/// A 20-byte EVM address.
+///
+/// Addresses are derived from public keys using Keccak-256 hashing.
+/// They can be displayed with EIP-55 mixed-case checksum encoding.
+///
+/// # Examples
+///
+/// ```rust
+/// use khodpay_signing::Address;
+///
+/// // Parse from hex string
+/// let addr: Address = "0x742d35Cc6634C0532925a3b844Bc454e4438f44e".parse().unwrap();
+///
+/// // Display with checksum
+/// println!("{}", addr);  // 0x742d35Cc6634C0532925a3b844Bc454e4438f44e
+/// ```
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Address([u8; 20]);
+
+impl Address {
+    /// The length of an address in bytes.
+    pub const LENGTH: usize = 20;
+
+    /// The zero address (0x0000...0000).
+    pub const ZERO: Address = Address([0u8; 20]);
+
+    /// Creates an address from a 20-byte array.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use khodpay_signing::Address;
+    ///
+    /// let bytes = [0u8; 20];
+    /// let addr = Address::from_bytes(bytes);
+    /// assert_eq!(addr, Address::ZERO);
+    /// ```
+    pub const fn from_bytes(bytes: [u8; 20]) -> Self {
+        Address(bytes)
+    }
+
+    /// Creates an address from a byte slice.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the slice is not exactly 20 bytes.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use khodpay_signing::Address;
+    ///
+    /// let bytes = vec![0u8; 20];
+    /// let addr = Address::from_slice(&bytes).unwrap();
+    /// assert_eq!(addr, Address::ZERO);
+    /// ```
+    pub fn from_slice(slice: &[u8]) -> Result<Self> {
+        if slice.len() != Self::LENGTH {
+            return Err(Error::InvalidAddress(format!(
+                "expected {} bytes, got {}",
+                Self::LENGTH,
+                slice.len()
+            )));
+        }
+        let mut bytes = [0u8; 20];
+        bytes.copy_from_slice(slice);
+        Ok(Address(bytes))
+    }
+
+    /// Derives an address from an uncompressed public key (64 bytes, without 0x04 prefix).
+    ///
+    /// The address is the last 20 bytes of the Keccak-256 hash of the public key.
+    ///
+    /// # Arguments
+    ///
+    /// * `pubkey` - 64-byte uncompressed public key (x and y coordinates)
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the public key is not exactly 64 bytes.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use khodpay_signing::Address;
+    ///
+    /// // Example public key (64 bytes)
+    /// let pubkey = [0u8; 64];
+    /// let addr = Address::from_public_key_bytes(&pubkey).unwrap();
+    /// ```
+    pub fn from_public_key_bytes(pubkey: &[u8]) -> Result<Self> {
+        if pubkey.len() != 64 {
+            return Err(Error::InvalidAddress(format!(
+                "public key must be 64 bytes (uncompressed without prefix), got {}",
+                pubkey.len()
+            )));
+        }
+
+        let hash = Keccak256::digest(pubkey);
+        let mut address = [0u8; 20];
+        address.copy_from_slice(&hash[12..32]);
+        Ok(Address(address))
+    }
+
+    /// Returns the address as a byte slice.
+    pub fn as_bytes(&self) -> &[u8; 20] {
+        &self.0
+    }
+
+    /// Returns the address as a byte array.
+    pub fn to_bytes(&self) -> [u8; 20] {
+        self.0
+    }
+
+    /// Returns the EIP-55 checksummed hex string (with 0x prefix).
+    ///
+    /// EIP-55 uses mixed-case hex encoding where the case of each letter
+    /// is determined by the corresponding nibble in the Keccak-256 hash
+    /// of the lowercase address.
+    pub fn to_checksum_string(&self) -> String {
+        let hex_addr = hex::encode(self.0);
+        let hash = Keccak256::digest(hex_addr.as_bytes());
+
+        let mut checksum = String::with_capacity(42);
+        checksum.push_str("0x");
+
+        for (i, c) in hex_addr.chars().enumerate() {
+            if c.is_ascii_digit() {
+                checksum.push(c);
+            } else {
+                // Get the corresponding nibble from the hash
+                let hash_byte = hash[i / 2];
+                let hash_nibble = if i % 2 == 0 {
+                    hash_byte >> 4
+                } else {
+                    hash_byte & 0x0f
+                };
+
+                if hash_nibble >= 8 {
+                    checksum.push(c.to_ascii_uppercase());
+                } else {
+                    checksum.push(c.to_ascii_lowercase());
+                }
+            }
+        }
+
+        checksum
+    }
+
+    /// Validates an EIP-55 checksummed address string.
+    ///
+    /// Returns `true` if the address has valid checksum or is all lowercase/uppercase.
+    pub fn validate_checksum(s: &str) -> bool {
+        let s = s.strip_prefix("0x").unwrap_or(s);
+        if s.len() != 40 {
+            return false;
+        }
+
+        // All lowercase or all uppercase is valid (no checksum)
+        let is_all_lower = s.chars().all(|c| !c.is_ascii_uppercase());
+        let is_all_upper = s.chars().all(|c| !c.is_ascii_lowercase());
+        if is_all_lower || is_all_upper {
+            return true;
+        }
+
+        // Validate mixed-case checksum
+        let lower = s.to_lowercase();
+        let hash = Keccak256::digest(lower.as_bytes());
+
+        for (i, c) in s.chars().enumerate() {
+            if c.is_ascii_alphabetic() {
+                let hash_byte = hash[i / 2];
+                let hash_nibble = if i % 2 == 0 {
+                    hash_byte >> 4
+                } else {
+                    hash_byte & 0x0f
+                };
+
+                let should_be_upper = hash_nibble >= 8;
+                if should_be_upper != c.is_ascii_uppercase() {
+                    return false;
+                }
+            }
+        }
+
+        true
+    }
+}
+
+impl FromStr for Address {
+    type Err = Error;
+
+    /// Parses an address from a hex string.
+    ///
+    /// Accepts both checksummed and non-checksummed addresses.
+    /// The `0x` prefix is optional.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use khodpay_signing::Address;
+    ///
+    /// // With 0x prefix
+    /// let addr: Address = "0x742d35Cc6634C0532925a3b844Bc454e4438f44e".parse().unwrap();
+    ///
+    /// // Without prefix
+    /// let addr: Address = "742d35Cc6634C0532925a3b844Bc454e4438f44e".parse().unwrap();
+    /// ```
+    fn from_str(s: &str) -> Result<Self> {
+        let s = s.strip_prefix("0x").unwrap_or(s);
+
+        if s.len() != 40 {
+            return Err(Error::InvalidAddress(format!(
+                "expected 40 hex characters, got {}",
+                s.len()
+            )));
+        }
+
+        let bytes = hex::decode(s).map_err(|e| Error::InvalidAddress(e.to_string()))?;
+
+        Self::from_slice(&bytes)
+    }
+}
+
+impl fmt::Display for Address {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.to_checksum_string())
+    }
+}
+
+impl fmt::Debug for Address {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Address({})", self.to_checksum_string())
+    }
+}
+
+impl fmt::LowerHex for Address {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if f.alternate() {
+            write!(f, "0x")?;
+        }
+        for byte in &self.0 {
+            write!(f, "{:02x}", byte)?;
+        }
+        Ok(())
+    }
+}
+
+impl AsRef<[u8]> for Address {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl From<[u8; 20]> for Address {
+    fn from(bytes: [u8; 20]) -> Self {
+        Address(bytes)
+    }
+}
+
+impl From<Address> for [u8; 20] {
+    fn from(addr: Address) -> Self {
+        addr.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ==================== Construction Tests ====================
+
+    #[test]
+    fn test_from_bytes() {
+        let bytes = [1u8; 20];
+        let addr = Address::from_bytes(bytes);
+        assert_eq!(addr.to_bytes(), bytes);
+    }
+
+    #[test]
+    fn test_from_slice_valid() {
+        let bytes = vec![2u8; 20];
+        let addr = Address::from_slice(&bytes).unwrap();
+        assert_eq!(addr.as_bytes(), &[2u8; 20]);
+    }
+
+    #[test]
+    fn test_from_slice_invalid_length() {
+        let bytes = vec![0u8; 19];
+        assert!(Address::from_slice(&bytes).is_err());
+
+        let bytes = vec![0u8; 21];
+        assert!(Address::from_slice(&bytes).is_err());
+    }
+
+    #[test]
+    fn test_zero_address() {
+        assert_eq!(Address::ZERO.to_bytes(), [0u8; 20]);
+    }
+
+    // ==================== Parsing Tests ====================
+
+    #[test]
+    fn test_parse_with_prefix() {
+        let addr: Address = "0x742d35Cc6634C0532925a3b844Bc454e4438f44e"
+            .parse()
+            .unwrap();
+        assert_eq!(
+            addr.to_checksum_string(),
+            "0x742d35Cc6634C0532925a3b844Bc454e4438f44e"
+        );
+    }
+
+    #[test]
+    fn test_parse_without_prefix() {
+        let addr: Address = "742d35Cc6634C0532925a3b844Bc454e4438f44e"
+            .parse()
+            .unwrap();
+        assert_eq!(
+            addr.to_checksum_string(),
+            "0x742d35Cc6634C0532925a3b844Bc454e4438f44e"
+        );
+    }
+
+    #[test]
+    fn test_parse_lowercase() {
+        let addr: Address = "0x742d35cc6634c0532925a3b844bc454e4438f44e"
+            .parse()
+            .unwrap();
+        // Should still produce checksummed output
+        assert_eq!(
+            addr.to_checksum_string(),
+            "0x742d35Cc6634C0532925a3b844Bc454e4438f44e"
+        );
+    }
+
+    #[test]
+    fn test_parse_uppercase() {
+        let addr: Address = "0x742D35CC6634C0532925A3B844BC454E4438F44E"
+            .parse()
+            .unwrap();
+        assert_eq!(
+            addr.to_checksum_string(),
+            "0x742d35Cc6634C0532925a3b844Bc454e4438f44e"
+        );
+    }
+
+    #[test]
+    fn test_parse_invalid_length() {
+        assert!("0x742d35".parse::<Address>().is_err());
+        assert!("0x742d35Cc6634C0532925a3b844Bc454e4438f44e00"
+            .parse::<Address>()
+            .is_err());
+    }
+
+    #[test]
+    fn test_parse_invalid_hex() {
+        assert!("0x742d35Cc6634C0532925a3b844Bc454e4438fXXX"
+            .parse::<Address>()
+            .is_err());
+    }
+
+    // ==================== Checksum Tests ====================
+
+    #[test]
+    fn test_checksum_encoding() {
+        // Known test vectors from EIP-55
+        let test_cases = [
+            "0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed",
+            "0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359",
+            "0xdbF03B407c01E7cD3CBea99509d93f8DDDC8C6FB",
+            "0xD1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb",
+        ];
+
+        for expected in test_cases {
+            let addr: Address = expected.parse().unwrap();
+            assert_eq!(addr.to_checksum_string(), expected);
+        }
+    }
+
+    #[test]
+    fn test_validate_checksum_valid() {
+        assert!(Address::validate_checksum(
+            "0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed"
+        ));
+        assert!(Address::validate_checksum(
+            "0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359"
+        ));
+    }
+
+    #[test]
+    fn test_validate_checksum_all_lowercase() {
+        assert!(Address::validate_checksum(
+            "0x5aaeb6053f3e94c9b9a09f33669435e7ef1beaed"
+        ));
+    }
+
+    #[test]
+    fn test_validate_checksum_all_uppercase() {
+        assert!(Address::validate_checksum(
+            "0x5AAEB6053F3E94C9B9A09F33669435E7EF1BEAED"
+        ));
+    }
+
+    #[test]
+    fn test_validate_checksum_invalid() {
+        // Wrong case on one character
+        assert!(!Address::validate_checksum(
+            "0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAeD"
+        )); // Last 'd' should be lowercase
+    }
+
+    // ==================== Public Key Derivation Tests ====================
+
+    #[test]
+    fn test_from_public_key_bytes() {
+        // Known test vector
+        // Public key for private key: 0x0000000000000000000000000000000000000000000000000000000000000001
+        let pubkey = hex::decode(
+            "79BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798\
+             483ADA7726A3C4655DA4FBFC0E1108A8FD17B448A68554199C47D08FFB10D4B8",
+        )
+        .unwrap();
+
+        let addr = Address::from_public_key_bytes(&pubkey).unwrap();
+        assert_eq!(
+            addr.to_checksum_string(),
+            "0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf"
+        );
+    }
+
+    #[test]
+    fn test_from_public_key_bytes_invalid_length() {
+        let pubkey = vec![0u8; 63];
+        assert!(Address::from_public_key_bytes(&pubkey).is_err());
+
+        let pubkey = vec![0u8; 65];
+        assert!(Address::from_public_key_bytes(&pubkey).is_err());
+    }
+
+    // ==================== Display Tests ====================
+
+    #[test]
+    fn test_display() {
+        let addr: Address = "0x742d35Cc6634C0532925a3b844Bc454e4438f44e"
+            .parse()
+            .unwrap();
+        assert_eq!(
+            format!("{}", addr),
+            "0x742d35Cc6634C0532925a3b844Bc454e4438f44e"
+        );
+    }
+
+    #[test]
+    fn test_debug() {
+        let addr: Address = "0x742d35Cc6634C0532925a3b844Bc454e4438f44e"
+            .parse()
+            .unwrap();
+        assert_eq!(
+            format!("{:?}", addr),
+            "Address(0x742d35Cc6634C0532925a3b844Bc454e4438f44e)"
+        );
+    }
+
+    #[test]
+    fn test_lower_hex() {
+        let addr: Address = "0x742d35Cc6634C0532925a3b844Bc454e4438f44e"
+            .parse()
+            .unwrap();
+        assert_eq!(
+            format!("{:x}", addr),
+            "742d35cc6634c0532925a3b844bc454e4438f44e"
+        );
+        assert_eq!(
+            format!("{:#x}", addr),
+            "0x742d35cc6634c0532925a3b844bc454e4438f44e"
+        );
+    }
+
+    // ==================== Equality Tests ====================
+
+    #[test]
+    fn test_equality() {
+        let addr1: Address = "0x742d35Cc6634C0532925a3b844Bc454e4438f44e"
+            .parse()
+            .unwrap();
+        let addr2: Address = "0x742d35cc6634c0532925a3b844bc454e4438f44e"
+            .parse()
+            .unwrap();
+        let addr3: Address = "0x0000000000000000000000000000000000000000"
+            .parse()
+            .unwrap();
+
+        assert_eq!(addr1, addr2);
+        assert_ne!(addr1, addr3);
+        assert_eq!(addr3, Address::ZERO);
+    }
+
+    // ==================== Conversion Tests ====================
+
+    #[test]
+    fn test_from_array() {
+        let bytes = [3u8; 20];
+        let addr: Address = bytes.into();
+        assert_eq!(addr.to_bytes(), bytes);
+    }
+
+    #[test]
+    fn test_into_array() {
+        let addr = Address::from_bytes([4u8; 20]);
+        let bytes: [u8; 20] = addr.into();
+        assert_eq!(bytes, [4u8; 20]);
+    }
+
+    #[test]
+    fn test_as_ref() {
+        let addr = Address::from_bytes([5u8; 20]);
+        let slice: &[u8] = addr.as_ref();
+        assert_eq!(slice, &[5u8; 20]);
+    }
+
+    // ==================== Hash Tests ====================
+
+    #[test]
+    fn test_hash() {
+        use std::collections::HashSet;
+
+        let addr1: Address = "0x742d35Cc6634C0532925a3b844Bc454e4438f44e"
+            .parse()
+            .unwrap();
+        let addr2: Address = "0x0000000000000000000000000000000000000000"
+            .parse()
+            .unwrap();
+
+        let mut set = HashSet::new();
+        set.insert(addr1);
+        set.insert(addr2);
+
+        assert!(set.contains(&addr1));
+        assert!(set.contains(&addr2));
+        assert_eq!(set.len(), 2);
+    }
+}

--- a/crates/khodpay-signing/src/lib.rs
+++ b/crates/khodpay-signing/src/lib.rs
@@ -47,11 +47,15 @@
 #![warn(rustdoc::broken_intra_doc_links)]
 #![deny(unsafe_code)]
 
+mod address;
 mod chain_id;
 mod error;
+mod wei;
 
+pub use address::Address;
 pub use chain_id::ChainId;
 pub use error::Error;
+pub use wei::{Wei, ETHER, GWEI};
 
 /// Result type alias for signing operations.
 pub type Result<T> = std::result::Result<T, Error>;

--- a/crates/khodpay-signing/src/wei.rs
+++ b/crates/khodpay-signing/src/wei.rs
@@ -1,0 +1,488 @@
+//! Wei type for EVM transaction values.
+//!
+//! Wei is the smallest unit of Ether/BNB. This module provides a wrapper
+//! around U256 with convenient conversion methods.
+
+use primitive_types::U256;
+use std::fmt;
+use std::ops::{Add, Mul, Sub};
+use std::str::FromStr;
+
+use crate::{Error, Result};
+
+/// The number of wei in one gwei (10^9).
+pub const GWEI: u64 = 1_000_000_000;
+
+/// The number of wei in one ether/BNB (10^18).
+pub const ETHER: u64 = 1_000_000_000_000_000_000;
+
+/// A value in wei (smallest EVM currency unit).
+///
+/// Wei is a wrapper around U256 that provides convenient methods for
+/// working with EVM currency values.
+///
+/// # Unit Conversions
+///
+/// - 1 ether = 10^18 wei
+/// - 1 gwei = 10^9 wei
+/// - 1 wei = 1 wei
+///
+/// # Examples
+///
+/// ```rust
+/// use khodpay_signing::Wei;
+///
+/// // Create from different units
+/// let one_ether = Wei::from_ether(1);
+/// let one_gwei = Wei::from_gwei(1);
+/// let one_wei = Wei::from_wei(1u64);
+///
+/// // Arithmetic
+/// let total = one_gwei + one_wei;
+///
+/// // Display
+/// println!("{} wei", one_ether);  // 1000000000000000000 wei
+/// ```
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct Wei(U256);
+
+impl Wei {
+    /// Zero wei.
+    pub const ZERO: Wei = Wei(U256::zero());
+
+    /// Creates a Wei value from a U256.
+    pub const fn from_u256(value: U256) -> Self {
+        Wei(value)
+    }
+
+    /// Creates a Wei value from wei (no conversion).
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use khodpay_signing::Wei;
+    ///
+    /// let value = Wei::from_wei(1000u64);
+    /// assert_eq!(value.as_u64(), Some(1000));
+    /// ```
+    pub fn from_wei<T: Into<U256>>(wei: T) -> Self {
+        Wei(wei.into())
+    }
+
+    /// Creates a Wei value from gwei.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use khodpay_signing::Wei;
+    ///
+    /// let value = Wei::from_gwei(5);
+    /// assert_eq!(value.as_u64(), Some(5_000_000_000));
+    /// ```
+    pub fn from_gwei(gwei: u64) -> Self {
+        Wei(U256::from(gwei) * U256::from(GWEI))
+    }
+
+    /// Creates a Wei value from ether/BNB.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use khodpay_signing::Wei;
+    ///
+    /// let value = Wei::from_ether(1);
+    /// assert_eq!(value.to_string(), "1000000000000000000");
+    /// ```
+    pub fn from_ether(ether: u64) -> Self {
+        Wei(U256::from(ether) * U256::from(ETHER))
+    }
+
+    /// Returns the value as U256.
+    pub const fn as_u256(&self) -> U256 {
+        self.0
+    }
+
+    /// Returns the value as u64 if it fits.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use khodpay_signing::Wei;
+    ///
+    /// let small = Wei::from_wei(1000u64);
+    /// assert_eq!(small.as_u64(), Some(1000));
+    ///
+    /// let large = Wei::from_ether(1000000000000);
+    /// assert_eq!(large.as_u64(), None);  // Too large for u64
+    /// ```
+    pub fn as_u64(&self) -> Option<u64> {
+        if self.0 <= U256::from(u64::MAX) {
+            Some(self.0.as_u64())
+        } else {
+            None
+        }
+    }
+
+    /// Returns the value as u128 if it fits.
+    pub fn as_u128(&self) -> Option<u128> {
+        if self.0 <= U256::from(u128::MAX) {
+            Some(self.0.as_u128())
+        } else {
+            None
+        }
+    }
+
+    /// Converts to gwei (truncates).
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use khodpay_signing::Wei;
+    ///
+    /// let value = Wei::from_gwei(5);
+    /// assert_eq!(value.to_gwei(), 5);
+    /// ```
+    pub fn to_gwei(&self) -> u64 {
+        (self.0 / U256::from(GWEI)).as_u64()
+    }
+
+    /// Converts to ether (truncates).
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use khodpay_signing::Wei;
+    ///
+    /// let value = Wei::from_ether(5);
+    /// assert_eq!(value.to_ether(), 5);
+    /// ```
+    pub fn to_ether(&self) -> u64 {
+        (self.0 / U256::from(ETHER)).as_u64()
+    }
+
+    /// Returns `true` if the value is zero.
+    pub fn is_zero(&self) -> bool {
+        self.0.is_zero()
+    }
+
+    /// Returns the value as a byte array in big-endian format.
+    pub fn to_be_bytes(&self) -> [u8; 32] {
+        let mut bytes = [0u8; 32];
+        self.0.to_big_endian(&mut bytes);
+        bytes
+    }
+
+    /// Creates a Wei value from big-endian bytes.
+    pub fn from_be_bytes(bytes: &[u8]) -> Self {
+        Wei(U256::from_big_endian(bytes))
+    }
+}
+
+impl From<u64> for Wei {
+    fn from(value: u64) -> Self {
+        Wei::from_wei(value)
+    }
+}
+
+impl From<u128> for Wei {
+    fn from(value: u128) -> Self {
+        Wei::from_wei(value)
+    }
+}
+
+impl From<U256> for Wei {
+    fn from(value: U256) -> Self {
+        Wei(value)
+    }
+}
+
+impl From<Wei> for U256 {
+    fn from(wei: Wei) -> Self {
+        wei.0
+    }
+}
+
+impl Add for Wei {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        Wei(self.0 + rhs.0)
+    }
+}
+
+impl Sub for Wei {
+    type Output = Self;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        Wei(self.0 - rhs.0)
+    }
+}
+
+impl Mul<u64> for Wei {
+    type Output = Self;
+
+    fn mul(self, rhs: u64) -> Self::Output {
+        Wei(self.0 * U256::from(rhs))
+    }
+}
+
+impl FromStr for Wei {
+    type Err = Error;
+
+    /// Parses a Wei value from a decimal string.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use khodpay_signing::Wei;
+    ///
+    /// let value: Wei = "1000000000".parse().unwrap();
+    /// assert_eq!(value, Wei::from_gwei(1));
+    /// ```
+    fn from_str(s: &str) -> Result<Self> {
+        U256::from_dec_str(s)
+            .map(Wei)
+            .map_err(|e| Error::InvalidValue(e.to_string()))
+    }
+}
+
+impl fmt::Display for Wei {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl fmt::Debug for Wei {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Wei({})", self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ==================== Construction Tests ====================
+
+    #[test]
+    fn test_from_wei() {
+        let value = Wei::from_wei(1000u64);
+        assert_eq!(value.as_u64(), Some(1000));
+    }
+
+    #[test]
+    fn test_from_gwei() {
+        let value = Wei::from_gwei(1);
+        assert_eq!(value.as_u64(), Some(1_000_000_000));
+    }
+
+    #[test]
+    fn test_from_gwei_multiple() {
+        let value = Wei::from_gwei(5);
+        assert_eq!(value.as_u64(), Some(5_000_000_000));
+    }
+
+    #[test]
+    fn test_from_ether() {
+        let value = Wei::from_ether(1);
+        assert_eq!(value.as_u64(), Some(1_000_000_000_000_000_000));
+    }
+
+    #[test]
+    fn test_from_ether_multiple() {
+        let value = Wei::from_ether(2);
+        assert_eq!(value.as_u64(), Some(2_000_000_000_000_000_000));
+    }
+
+    #[test]
+    fn test_zero() {
+        assert!(Wei::ZERO.is_zero());
+        assert_eq!(Wei::ZERO.as_u64(), Some(0));
+    }
+
+    // ==================== Conversion Tests ====================
+
+    #[test]
+    fn test_to_gwei() {
+        let value = Wei::from_gwei(5);
+        assert_eq!(value.to_gwei(), 5);
+    }
+
+    #[test]
+    fn test_to_gwei_truncates() {
+        let value = Wei::from_wei(5_500_000_000u64);
+        assert_eq!(value.to_gwei(), 5); // Truncates 0.5 gwei
+    }
+
+    #[test]
+    fn test_to_ether() {
+        let value = Wei::from_ether(5);
+        assert_eq!(value.to_ether(), 5);
+    }
+
+    #[test]
+    fn test_to_ether_truncates() {
+        let value = Wei::from_gwei(1_500_000_000); // 1.5 ether
+        assert_eq!(value.to_ether(), 1); // Truncates 0.5 ether
+    }
+
+    #[test]
+    fn test_as_u64_overflow() {
+        let large = Wei::from_ether(100) * 1_000_000_000;
+        assert_eq!(large.as_u64(), None);
+    }
+
+    #[test]
+    fn test_as_u128() {
+        let value = Wei::from_ether(1);
+        assert_eq!(value.as_u128(), Some(1_000_000_000_000_000_000u128));
+    }
+
+    // ==================== Arithmetic Tests ====================
+
+    #[test]
+    fn test_add() {
+        let a = Wei::from_gwei(1);
+        let b = Wei::from_gwei(2);
+        let sum = a + b;
+        assert_eq!(sum, Wei::from_gwei(3));
+    }
+
+    #[test]
+    fn test_sub() {
+        let a = Wei::from_gwei(5);
+        let b = Wei::from_gwei(2);
+        let diff = a - b;
+        assert_eq!(diff, Wei::from_gwei(3));
+    }
+
+    #[test]
+    fn test_mul() {
+        let a = Wei::from_gwei(5);
+        let product = a * 3;
+        assert_eq!(product, Wei::from_gwei(15));
+    }
+
+    // ==================== Parsing Tests ====================
+
+    #[test]
+    fn test_from_str() {
+        let value: Wei = "1000000000".parse().unwrap();
+        assert_eq!(value, Wei::from_gwei(1));
+    }
+
+    #[test]
+    fn test_from_str_large() {
+        let value: Wei = "1000000000000000000".parse().unwrap();
+        assert_eq!(value, Wei::from_ether(1));
+    }
+
+    #[test]
+    fn test_from_str_invalid() {
+        assert!("not_a_number".parse::<Wei>().is_err());
+    }
+
+    // ==================== Display Tests ====================
+
+    #[test]
+    fn test_display() {
+        let value = Wei::from_gwei(1);
+        assert_eq!(format!("{}", value), "1000000000");
+    }
+
+    #[test]
+    fn test_debug() {
+        let value = Wei::from_gwei(1);
+        assert_eq!(format!("{:?}", value), "Wei(1000000000)");
+    }
+
+    // ==================== Bytes Tests ====================
+
+    #[test]
+    fn test_to_be_bytes() {
+        let value = Wei::from_wei(256u64);
+        let bytes = value.to_be_bytes();
+        assert_eq!(bytes[30], 1);
+        assert_eq!(bytes[31], 0);
+    }
+
+    #[test]
+    fn test_from_be_bytes() {
+        let mut bytes = [0u8; 32];
+        bytes[31] = 100;
+        let value = Wei::from_be_bytes(&bytes);
+        assert_eq!(value.as_u64(), Some(100));
+    }
+
+    #[test]
+    fn test_bytes_round_trip() {
+        let original = Wei::from_ether(123);
+        let bytes = original.to_be_bytes();
+        let recovered = Wei::from_be_bytes(&bytes);
+        assert_eq!(original, recovered);
+    }
+
+    // ==================== Equality Tests ====================
+
+    #[test]
+    fn test_equality() {
+        let a = Wei::from_gwei(5);
+        let b = Wei::from_gwei(5);
+        let c = Wei::from_gwei(10);
+
+        assert_eq!(a, b);
+        assert_ne!(a, c);
+    }
+
+    #[test]
+    fn test_ordering() {
+        let a = Wei::from_gwei(5);
+        let b = Wei::from_gwei(10);
+
+        assert!(a < b);
+        assert!(b > a);
+    }
+
+    // ==================== From Trait Tests ====================
+
+    #[test]
+    fn test_from_u64() {
+        let value: Wei = 1000u64.into();
+        assert_eq!(value.as_u64(), Some(1000));
+    }
+
+    #[test]
+    fn test_from_u128() {
+        let value: Wei = 1000u128.into();
+        assert_eq!(value.as_u128(), Some(1000));
+    }
+
+    #[test]
+    fn test_from_u256() {
+        let u256 = U256::from(1000);
+        let value: Wei = u256.into();
+        assert_eq!(value.as_u64(), Some(1000));
+    }
+
+    #[test]
+    fn test_into_u256() {
+        let value = Wei::from_wei(1000u64);
+        let u256: U256 = value.into();
+        assert_eq!(u256, U256::from(1000));
+    }
+
+    // ==================== Hash Tests ====================
+
+    #[test]
+    fn test_hash() {
+        use std::collections::HashSet;
+
+        let mut set = HashSet::new();
+        set.insert(Wei::from_gwei(1));
+        set.insert(Wei::from_gwei(2));
+
+        assert!(set.contains(&Wei::from_gwei(1)));
+        assert!(set.contains(&Wei::from_gwei(2)));
+        assert!(!set.contains(&Wei::from_gwei(3)));
+    }
+}

--- a/docs/implementations/signing_tasks.md
+++ b/docs/implementations/signing_tasks.md
@@ -21,7 +21,7 @@ This crate provides EVM transaction signing for BSC (BNB Smart Chain) using EIP-
   ```
   > **Note**: `ChainId` ≠ `CoinType`. CoinType (60) → derivation path. ChainId (56) → transaction.
 
-- [ ] **Task 03**: Define Address and Wei types (TDD)
+- [x] **Task 03**: Define Address and Wei types (TDD)
   - `Address`: 20-byte EVM address with hex parsing, EIP-55 checksum, derivation from public key
   - `Wei`: U256 wrapper with `from_gwei()`, `from_ether()` helpers
 


### PR DESCRIPTION
- Add Address type with EIP-55 checksum encoding/validation
- Add from_public_key_bytes() for deriving address from pubkey
- Add Wei type with from_wei/gwei/ether conversions
- Add arithmetic ops and byte serialization for Wei
- Add 55 unit tests for full coverage