### PR TITLE
feat(signing): add zeroize for sensitive data

### DIFF
--- a/docs/implementations/signing_tasks.md
+++ b/docs/implementations/signing_tasks.md
@@ -78,7 +78,7 @@ This crate provides EVM transaction signing for BSC (BNB Smart Chain) using EIP-
   - Full workflow: mnemonic → bip44 → sign BSC transaction
   - Validation: `max_fee >= max_priority_fee`, `gas_limit >= 21000`
 
-- [ ] **Task 10**: Security: zeroize sensitive data
+- [x] **Task 10**: Security: zeroize sensitive data
 
 ---
 


### PR DESCRIPTION
- Add Zeroize derive to Signature struct (r, s, v)
- Wrap intermediate private key bytes in Zeroizing<[u8; 32]>
- Add security documentation for Bip44Signer and Signature
- k256::SigningKey already implements Zeroize internally
- Add test_zeroize() to verify zeroing behavior