### PR TITLE
docs: add khodpay-signing to README and integration guide

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,9 +43,9 @@ checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64ct"
-version = "1.8.0"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
+checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
 
 [[package]]
 name = "bip39"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,8 @@ documentation = "https://docs.rs/khodpay-wallet"
 homepage = "https://github.com/khodpay/rust-wallet"
 edition = "2021"
 rust-version = "1.81"
+
+# Pin dependencies that require edition 2024 to older versions
+# until CI runners are updated to Rust 1.85+
+[workspace.dependencies]
+base64ct = "=1.7.3"

--- a/crates/khodpay-signing/src/chain_id.rs
+++ b/crates/khodpay-signing/src/chain_id.rs
@@ -285,10 +285,8 @@ mod tests {
     #[test]
     fn test_clone_copy() {
         let original = ChainId::BscMainnet;
-        let cloned = original.clone();
-        let copied = original;
+        let copied = original; // Copy trait
 
-        assert_eq!(original, cloned);
         assert_eq!(original, copied);
     }
 

--- a/crates/khodpay-signing/src/signer.rs
+++ b/crates/khodpay-signing/src/signer.rs
@@ -218,8 +218,8 @@ pub fn recover_signer(hash: &[u8; 32], signature: &Signature) -> Result<Address>
     let recovery_id = RecoveryId::from_byte(signature.v)
         .ok_or_else(|| Error::SigningError("Invalid recovery ID".to_string()))?;
 
-    let r = k256::FieldBytes::from_slice(&signature.r);
-    let s = k256::FieldBytes::from_slice(&signature.s);
+    let r: &k256::FieldBytes = (&signature.r).into();
+    let s: &k256::FieldBytes = (&signature.s).into();
 
     let ecdsa_sig = k256::ecdsa::Signature::from_scalars(*r, *s)
         .map_err(|e| Error::SigningError(format!("Invalid signature: {}", e)))?;


### PR DESCRIPTION
- Add signing crate to workspace README with features and examples
- Update INTEGRATION_GUIDE with BSC transaction signing examples
- Add crate README with comprehensive documentation
- Fix clippy warnings (clone on Copy type, deprecated from_slice)
- Pin base64ct to 1.7.3 for Rust 1.81 compatibility